### PR TITLE
Don't load devices if the plugin dropped support for it

### DIFF
--- a/libnymea-core/devices/devicemanagerimplementation.cpp
+++ b/libnymea-core/devices/devicemanagerimplementation.cpp
@@ -1142,6 +1142,12 @@ void DeviceManagerImplementation::loadConfiguredDevices()
             continue;
         }
 
+        // Cross-check if this plugin still implements this device class
+        if (!plugin->supportedDevices().contains(deviceClass)) {
+            qCWarning(dcDeviceManager()) << "Not loading device" << deviceName << idString << "because plugin" << plugin->pluginName() << "has removed support for it.";
+            settings.endGroup(); // DeviceId
+            continue;
+        }
         Device *device = new Device(plugin, deviceClass, DeviceId(idString), this);
         device->m_autoCreated = settings.value("autoCreated").toBool();
         device->setName(deviceName);


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

yes

Did you update the documentation?

N/A

Did you update translations (cd builddir && make lupdate)?

No string change
