### PR TITLE
Threaded log database

### DIFF
--- a/libnymea-core/jsonrpc/logginghandler.cpp
+++ b/libnymea-core/jsonrpc/logginghandler.cpp
@@ -140,16 +140,27 @@ JsonReply* LoggingHandler::GetLogEntries(const QVariantMap &params) const
 {
     LogFilter filter = unpackLogFilter(params);
 
-    QVariantList entries;
-    foreach (const LogEntry &entry, NymeaCore::instance()->logEngine()->logEntries(filter)) {
-        entries.append(packLogEntry(entry));
-    }
-    QVariantMap returns;
-    returns.insert("loggingError", enumValueName<Logging::LoggingError>(Logging::LoggingErrorNoError));
-    returns.insert("logEntries", entries);
-    returns.insert("offset", filter.offset());
-    returns.insert("count", entries.count());
-    return createReply(returns);
+    LogEngineFetchJob *job = NymeaCore::instance()->logEngine()->logEntries(filter);
+
+    JsonReply *reply = createAsyncReply("GetLogEntries");
+
+    connect(job, &LogEngineFetchJob::finished, reply, [this, reply, job, filter](){
+
+        QVariantList entries;
+        foreach (const LogEntry &entry, job->results()) {
+            entries.append(packLogEntry(entry));
+        }
+        QVariantMap returns;
+        returns.insert("loggingError", enumValueName<Logging::LoggingError>(Logging::LoggingErrorNoError));
+        returns.insert("logEntries", entries);
+        returns.insert("offset", filter.offset());
+        returns.insert("count", entries.count());
+
+        reply->setData(returns);
+        reply->finished();
+    });
+
+    return reply;
 }
 
 QVariantMap LoggingHandler::packLogEntry(const LogEntry &logEntry)

--- a/libnymea-core/jsonrpc/logginghandler.cpp
+++ b/libnymea-core/jsonrpc/logginghandler.cpp
@@ -140,11 +140,11 @@ JsonReply* LoggingHandler::GetLogEntries(const QVariantMap &params) const
 {
     LogFilter filter = unpackLogFilter(params);
 
-    LogEngineFetchJob *job = NymeaCore::instance()->logEngine()->logEntries(filter);
+    LogEntriesFetchJob *job = NymeaCore::instance()->logEngine()->fetchLogEntries(filter);
 
     JsonReply *reply = createAsyncReply("GetLogEntries");
 
-    connect(job, &LogEngineFetchJob::finished, reply, [this, reply, job, filter](){
+    connect(job, &LogEntriesFetchJob::finished, reply, [reply, job, filter](){
 
         QVariantList entries;
         foreach (const LogEntry &entry, job->results()) {

--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -479,7 +479,6 @@ void LogEngine::appendLogEntry(const LogEntry &entry)
             qCWarning(dcLogEngine) << "Error writing log entry. Driver error:" << job->error().driverText() << "Database error:" << job->error().number() << job->error().databaseText();
             qCWarning(dcLogEngine) << entry;
             m_dbMalformed = true;
-            processQueue();
             return;
         }
 

--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -180,13 +180,14 @@ LogEngine::LogEngine(const QString &driver, const QString &dbName, const QString
 /*! Destructs the \l{LogEngine}. */
 LogEngine::~LogEngine()
 {
+    qWarning() << "Destroying logEngine";
     // Process the job queue before allowing to shut down
-    while (!m_jobQueue.isEmpty()) {
-        qApp->processEvents();
-    }
-    if (!m_jobWatcher.isFinished()) {
+    while (!m_jobQueue.isEmpty() || !m_jobWatcher.isFinished()) {
+        qWarning() << "Waiting for job to finish...";
         m_jobWatcher.waitForFinished();
     }
+    qWarning() << "Done waiting";
+    qCDebug(dcLogEngine()) << "Closing Database";
     m_db.close();
 }
 

--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -172,15 +172,21 @@ LogEngine::LogEngine(const QString &driver, const QString &dbName, const QString
         }
     }
 
-    checkDBSize();
-
     connect(&m_jobWatcher, SIGNAL(finished()), this, SLOT(handleJobFinished()));
 
+    checkDBSize();
 }
 
 /*! Destructs the \l{LogEngine}. */
 LogEngine::~LogEngine()
 {
+    // Process the job queue before allowing to shut down
+    while (!m_jobQueue.isEmpty()) {
+        qApp->processEvents();
+    }
+    if (!m_jobWatcher.isFinished()) {
+        m_jobWatcher.waitForFinished();
+    }
     m_db.close();
 }
 

--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -274,6 +274,11 @@ DevicesFetchJob *LogEngine::fetchDevices()
     return fetchJob;
 }
 
+bool LogEngine::jobsRunning() const
+{
+    return !m_jobQueue.isEmpty() || m_currentJob;
+}
+
 void LogEngine::setMaxLogEntries(int maxLogEntries, int overflow)
 {
     m_dbMaxSize = maxLogEntries;
@@ -547,12 +552,15 @@ void LogEngine::enqueJob(DatabaseJob *job)
 void LogEngine::processQueue()
 {
     if (m_jobQueue.isEmpty()) {
+        emit jobsRunningChanged();
         return;
     }
 
     if (m_currentJob) {
         return;
     }
+
+    emit jobsRunningChanged();
 
     if (m_dbMalformed) {
         qCWarning(dcLogEngine()) << "Database is malformed. Trying to recover...";

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -39,7 +39,8 @@
 namespace nymeaserver {
 
 class DatabaseJob;
-class LogEngineFetchJob;
+class LogEntriesFetchJob;
+class DevicesFetchJob;
 
 class LogEngine: public QObject
 {
@@ -48,7 +49,8 @@ public:
     LogEngine(const QString &driver, const QString &dbName, const QString &hostname = QString("127.0.0.1"), const QString &username = QString(), const QString &password = QString(), int maxDBSize = 50000, QObject *parent = nullptr);
     ~LogEngine();
 
-    LogEngineFetchJob *logEntries(const LogFilter &filter = LogFilter());
+    LogEntriesFetchJob *fetchLogEntries(const LogFilter &filter = LogFilter());
+    DevicesFetchJob *fetchDevices();
 
     void setMaxLogEntries(int maxLogEntries, int overflow);
     void clearDatabase();
@@ -122,24 +124,32 @@ private:
     QSqlQuery m_query;
 };
 
-class LogEngineFetchJob: public QObject
+class LogEntriesFetchJob: public QObject
 {
     Q_OBJECT
 public:
-    LogEngineFetchJob(QObject *parent): QObject(parent) {}
-
+    LogEntriesFetchJob(QObject *parent): QObject(parent) {}
     QList<LogEntry> results() { return m_results; }
-
 signals:
     void finished();
-
 private:
-    void addResult(const LogEntry &entry) { m_results.append(entry); }
     QList<LogEntry> m_results;
-
     friend class LogEngine;
-
 };
+
+class DevicesFetchJob: public QObject
+{
+    Q_OBJECT
+public:
+    DevicesFetchJob(QObject *parent): QObject(parent) {}
+    QList<DeviceId> results() { return m_results; }
+signals:
+    void finished();
+private:
+    QList<DeviceId> m_results;
+    friend class LogEngine;
+};
+
 }
 
 #endif

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -33,6 +33,8 @@
 #include <QObject>
 #include <QSqlDatabase>
 #include <QSqlQuery>
+#include <QSqlError>
+#include <QSqlRecord>
 #include <QTimer>
 #include <QFutureWatcher>
 
@@ -106,22 +108,30 @@ class DatabaseJob: public QObject
 {
     Q_OBJECT
 public:
-    DatabaseJob(const QString &queryString, const QSqlDatabase &db) {
-        m_query = QSqlQuery(db);
-        m_query.prepare(queryString);
+    DatabaseJob(const QSqlDatabase &db, const QString &queryString, const QStringList &bindValues = QStringList()):
+        m_db(db),
+        m_queryString(queryString),
+        m_bindValues(bindValues)
+    {
     }
 
-    // IMPORTANT: Make sure it only prepare()d but not executed
-    // QSQlQuery(QString, QSqlDatabase) implicitly executes!
-    DatabaseJob(const QSqlQuery &query): m_query(query) {}
-
-    QSqlQuery query() const { return m_query; }
+    QString executedQuery() const { return m_executedQuery; }
+    QSqlError error() const { return m_error; }
+    QList<QSqlRecord> results() const { return m_results; }
 
 signals:
     void finished();
 
 private:
-    QSqlQuery m_query;
+    QSqlDatabase m_db;
+    QString m_queryString;
+    QStringList m_bindValues;
+
+    QString m_executedQuery;
+    QSqlError m_error;
+    QList<QSqlRecord> m_results;
+
+    friend class LogEngine;
 };
 
 class LogEntriesFetchJob: public QObject

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -96,6 +96,7 @@ private:
     bool m_dbMalformed = false;
 
     QList<DatabaseJob*> m_jobQueue;
+    DatabaseJob *m_currentJob = nullptr;
     QFutureWatcher<DatabaseJob*> m_jobWatcher;
 };
 

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -103,7 +103,14 @@ class DatabaseJob: public QObject
 {
     Q_OBJECT
 public:
-    DatabaseJob(const QSqlQuery &query, QObject *parent): QObject(parent), m_query(query) {}
+    DatabaseJob(const QString &queryString, const QSqlDatabase &db) {
+        m_query = QSqlQuery(db);
+        m_query.prepare(queryString);
+    }
+
+    // IMPORTANT: Make sure it only prepare()d but not executed
+    // QSQlQuery(QString, QSqlDatabase) implicitly executes!
+    DatabaseJob(const QSqlQuery &query): m_query(query) {}
 
     QSqlQuery query() const { return m_query; }
 

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -54,6 +54,8 @@ public:
     LogEntriesFetchJob *fetchLogEntries(const LogFilter &filter = LogFilter());
     DevicesFetchJob *fetchDevices();
 
+    bool jobsRunning() const;
+
     void setMaxLogEntries(int maxLogEntries, int overflow);
     void clearDatabase();
 
@@ -73,6 +75,8 @@ public:
 signals:
     void logEntryAdded(const LogEntry &logEntry);
     void logDatabaseUpdated();
+
+    void jobsRunningChanged();
 
 private:
     bool initDB(const QString &username, const QString &password);

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -920,28 +920,6 @@ void NymeaCore::deviceManagerLoaded()
     onDateTimeChanged(m_timeManager->currentDateTime());
 
     emit initialized();
-
-    // Do some houskeeping...
-    qCDebug(dcApplication()) << "Starting housekeeping...";
-    QDateTime startTime = QDateTime::currentDateTime();
-    foreach (const DeviceId &deviceId, m_logger->devicesInLogs()) {
-        if (!m_deviceManager->findConfiguredDevice(deviceId)) {
-            qCDebug(dcApplication()) << "Cleaning stale device entries from log DB for device id" << deviceId;
-            m_logger->removeDeviceLogs(deviceId);
-        }
-    }
-
-    foreach (const DeviceId &deviceId, m_ruleEngine->devicesInRules()) {
-        if (!m_deviceManager->findConfiguredDevice(deviceId)) {
-            qCDebug(dcApplication()) << "Cleaning stale rule entries for device id" << deviceId;
-            foreach (const RuleId &ruleId, m_ruleEngine->findRules(deviceId)) {
-                m_ruleEngine->removeDeviceFromRule(ruleId, deviceId);
-            }
-        }
-    }
-
-    qCDebug(dcApplication()) << "Housekeeping done in" << startTime.msecsTo(QDateTime::currentDateTime()) << "ms.";
-
 }
 
 }

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -920,6 +920,29 @@ void NymeaCore::deviceManagerLoaded()
     onDateTimeChanged(m_timeManager->currentDateTime());
 
     emit initialized();
+
+    // Do some houskeeping...
+    qCDebug(dcApplication()) << "Starting housekeeping...";
+    QDateTime startTime = QDateTime::currentDateTime();
+    DevicesFetchJob *job = m_logger->fetchDevices();
+    connect(job, &DevicesFetchJob::finished, this, [this, job, startTime](){
+        foreach (const DeviceId &deviceId, job->results()) {
+            if (!m_deviceManager->findConfiguredDevice(deviceId)) {
+                qCDebug(dcApplication()) << "Cleaning stale device entries from log DB for device id" << deviceId;
+                m_logger->removeDeviceLogs(deviceId);
+            }
+        }
+        qCDebug(dcApplication()) << "Housekeeping done in" << startTime.msecsTo(QDateTime::currentDateTime()) << "ms.";
+    });
+
+    foreach (const DeviceId &deviceId, m_ruleEngine->devicesInRules()) {
+        if (!m_deviceManager->findConfiguredDevice(deviceId)) {
+            qCDebug(dcApplication()) << "Cleaning stale rule entries for device id" << deviceId;
+            foreach (const RuleId &ruleId, m_ruleEngine->findRules(deviceId)) {
+                m_ruleEngine->removeDeviceFromRule(ruleId, deviceId);
+            }
+        }
+    }
 }
 
 }

--- a/nymea.pro
+++ b/nymea.pro
@@ -58,8 +58,9 @@ INSTALLS += translations
 
 QMAKE_EXTRA_TARGETS += lupdate lrelease
 
-test.depends = licensecheck lrelease
-test.commands = LD_LIBRARY_PATH=$$top_builddir/libnymea-core:$$top_builddir/libnymea:$$top_builddir/tests/testlib make check
+test.depends = licensecheck
+test.depends += lrelease
+test.commands = LD_LIBRARY_PATH=$$top_builddir/libnymea-core:$$top_builddir/libnymea:$$top_builddir/tests/testlib make check TESTRUNNER=\"dbus-test-runner --bus-type=system --task\"
 QMAKE_EXTRA_TARGETS += test
 
 # Show doc files in project tree

--- a/tests/auto/autotests.pri
+++ b/tests/auto/autotests.pri
@@ -13,3 +13,6 @@ LIBS += -L$$top_builddir/libnymea/ -lnymea \
 
 target.path = /usr/tests
 INSTALLS += target
+
+test.commands = LD_LIBRARY_PATH=../../../libnymea:../../../libnymea-core/:../../testlib/ make check TESTRUNNER=\"dbus-test-runner --bus-type=system --task\"
+QMAKE_EXTRA_TARGETS += test

--- a/tests/auto/jsonrpc/testjsonrpc.cpp
+++ b/tests/auto/jsonrpc/testjsonrpc.cpp
@@ -991,18 +991,16 @@ void TestJSONRPC::stateChangeEmitsNotifications()
             break;
         }
     }
-    if (!found)
-        qDebug() << QJsonDocument::fromVariant(stateChangedVariants).toJson();
 
     QVERIFY2(found, "Could not find the correct Devices.StateChanged notification");
 
+    clientSpy.wait();
 
     // Make sure the logg notification contains all the stuff we expect
-    QVariantList loggEntryAddedVariants = checkNotifications(clientSpy, "Logging.LogEntryAdded");
-    QVERIFY2(!loggEntryAddedVariants.isEmpty(), "Did not get Logging.LogEntryAdded notification.");
-    qDebug() << "got" << loggEntryAddedVariants.count() << "Logging.LogEntryAdded notifications";
+    QVariantList logEntryAddedVariants = checkNotifications(clientSpy, "Logging.LogEntryAdded");
+    QVERIFY2(!logEntryAddedVariants.isEmpty(), "Did not get Logging.LogEntryAdded notification.");
     found = false;
-    foreach (const QVariant &loggEntryAddedVariant, loggEntryAddedVariants) {
+    foreach (const QVariant &loggEntryAddedVariant, logEntryAddedVariants) {
         if (loggEntryAddedVariant.toMap().value("params").toMap().value("logEntry").toMap().value("typeId").toUuid() == stateTypeId) {
             found = true;
             QCOMPARE(loggEntryAddedVariant.toMap().value("params").toMap().value("logEntry").toMap().value("source").toString(), QString("LoggingSourceStates"));
@@ -1010,8 +1008,6 @@ void TestJSONRPC::stateChangeEmitsNotifications()
             break;
         }
     }
-    if (!found)
-        qDebug() << QJsonDocument::fromVariant(loggEntryAddedVariants).toJson();
 
     QVERIFY2(found, "Could not find the corresponding Logging.LogEntryAdded notification");
 
@@ -1020,7 +1016,6 @@ void TestJSONRPC::stateChangeEmitsNotifications()
     QVariantList eventTriggeredVariants = checkNotifications(clientSpy, "Events.EventTriggered");
     QVERIFY2(!eventTriggeredVariants.isEmpty(), "Did not get Events.EventTriggered notification.");
     found = false;
-    qDebug() << "got" << eventTriggeredVariants.count() << "Events.EventTriggered notifications";
     foreach (const QVariant &eventTriggeredVariant, eventTriggeredVariants) {
         if (eventTriggeredVariant.toMap().value("params").toMap().value("event").toMap().value("eventTypeId").toUuid() == stateTypeId) {
             found = true;
@@ -1028,8 +1023,6 @@ void TestJSONRPC::stateChangeEmitsNotifications()
             break;
         }
     }
-    if (!found)
-        qDebug() << QJsonDocument::fromVariant(eventTriggeredVariants).toJson();
 
     QVERIFY2(found, "Could not find the corresponding Events.EventTriggered notification");
 
@@ -1108,6 +1101,7 @@ void TestJSONRPC::testPushButtonAuth()
 
 void TestJSONRPC::testPushButtonAuthInterrupt()
 {
+    enableNotifications({});
     PushButtonAgent pushButtonAgent;
     pushButtonAgent.init();
 

--- a/tests/auto/loggingdirect/testloggingdirect.cpp
+++ b/tests/auto/loggingdirect/testloggingdirect.cpp
@@ -82,8 +82,8 @@ void TestLoggingDirect::benchmarkDB()
     engine->setMaxLogEntries(prefill, overflow);
     engine->setMaxLogEntries(maxSize, overflow);
 
-    LogEngineFetchJob *job = engine->logEntries();
-    QSignalSpy fetchSpy(job, &LogEngineFetchJob::finished);
+    LogEntriesFetchJob *job = engine->fetchLogEntries();
+    QSignalSpy fetchSpy(job, &LogEntriesFetchJob::finished);
     fetchSpy.wait();
     QList<LogEntry> entries = job->results();
 
@@ -93,8 +93,8 @@ void TestLoggingDirect::benchmarkDB()
         engine->logSystemEvent(QDateTime::currentDateTime(), true);
     }
 
-    job = engine->logEntries();
-    QSignalSpy fetchSpy2(job, &LogEngineFetchJob::finished);
+    job = engine->fetchLogEntries();
+    QSignalSpy fetchSpy2(job, &LogEntriesFetchJob::finished);
     fetchSpy2.wait();
     entries = job->results();
 
@@ -106,8 +106,8 @@ void TestLoggingDirect::benchmarkDB()
     }
     QDateTime now = QDateTime::currentDateTime();
 
-    job = engine->logEntries();
-    QSignalSpy fetchSpy3(job, &LogEngineFetchJob::finished);
+    job = engine->fetchLogEntries();
+    QSignalSpy fetchSpy3(job, &LogEntriesFetchJob::finished);
     fetchSpy3.wait();
     entries = job->results();
 

--- a/tests/auto/rules/testrules.cpp
+++ b/tests/auto/rules/testrules.cpp
@@ -2312,7 +2312,11 @@ void TestRules::testStateBasedAction()
     LogFilter filter;
     filter.addDeviceId(m_mockDeviceId);
     filter.addTypeId(mockWithParamsActionTypeId);
-    QList<LogEntry> entries = NymeaCore::instance()->logEngine()->logEntries(filter);
+
+    LogEngineFetchJob *job = NymeaCore::instance()->logEngine()->logEntries(filter);
+    QSignalSpy fetchSpy(job, &LogEngineFetchJob::finished);
+    fetchSpy.wait();
+    QList<LogEntry> entries = job->results();
     qCDebug(dcTests()) << "Log entries:" << entries;
 
     // set bool state to false
@@ -2331,10 +2335,12 @@ void TestRules::testStateBasedAction()
     QCOMPARE(spy.count(), 1);
     reply->deleteLater();
 
-    entries = NymeaCore::instance()->logEngine()->logEntries(filter);
+    job = NymeaCore::instance()->logEngine()->logEntries(filter);
+    QSignalSpy fetchSpy2(job, &LogEngineFetchJob::finished);
+    fetchSpy2.wait();
+    entries = job->results();
+
     qCDebug(dcTests()) << "Log entries:" << entries;
-
-
 }
 
 void TestRules::removePolicyUpdate()

--- a/tests/auto/rules/testrules.cpp
+++ b/tests/auto/rules/testrules.cpp
@@ -2313,8 +2313,8 @@ void TestRules::testStateBasedAction()
     filter.addDeviceId(m_mockDeviceId);
     filter.addTypeId(mockWithParamsActionTypeId);
 
-    LogEngineFetchJob *job = NymeaCore::instance()->logEngine()->logEntries(filter);
-    QSignalSpy fetchSpy(job, &LogEngineFetchJob::finished);
+    LogEntriesFetchJob *job = NymeaCore::instance()->logEngine()->fetchLogEntries(filter);
+    QSignalSpy fetchSpy(job, &LogEntriesFetchJob::finished);
     fetchSpy.wait();
     QList<LogEntry> entries = job->results();
     qCDebug(dcTests()) << "Log entries:" << entries;
@@ -2335,8 +2335,8 @@ void TestRules::testStateBasedAction()
     QCOMPARE(spy.count(), 1);
     reply->deleteLater();
 
-    job = NymeaCore::instance()->logEngine()->logEntries(filter);
-    QSignalSpy fetchSpy2(job, &LogEngineFetchJob::finished);
+    job = NymeaCore::instance()->logEngine()->fetchLogEntries(filter);
+    QSignalSpy fetchSpy2(job, &LogEntriesFetchJob::finished);
     fetchSpy2.wait();
     entries = job->results();
 

--- a/tests/scripts/gettags.sh
+++ b/tests/scripts/gettags.sh
@@ -2,6 +2,10 @@
 
 if [ -z $1 ]; then
   echo "usage: $0 host"
-else
-  (echo '{"id":1, "method":"Tags.GetTags"}'; sleep 1) | nc $1 2222
+  exit 1
 fi
+
+cat << EOD | nc $1 2222
+{"id":0, "method":"JSONRPC.Hello"}
+{"id":1, "method":"Tags.GetTags"}
+EOD

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -190,8 +190,9 @@ QVariantList NymeaTestBase::checkNotifications(const QSignalSpy &spy, const QStr
         // Make sure the response it a valid JSON string
         QJsonParseError error;
         QJsonDocument jsonDoc = QJsonDocument::fromJson(spy.at(i).last().toByteArray(), &error);
+//        qCDebug(dcTests()) << "Got packet:" << qUtf8Printable(jsonDoc.toJson());
         if (error.error != QJsonParseError::NoError) {
-            qWarning() << "JSON parser error" << error.errorString();
+            qCWarning(dcTests()) << "JSON parser error" << error.errorString();
             return notificationList;
         }
 


### PR DESCRIPTION
This
a) makes the log db threaded by using QtConcurrent to run queries in a
different thread but still keeps ordering of the queries and always
only allows a single query at a time (QSql is not threadsafe). This fixes
removeDevice calls failing if we take more than $jsonprc_timeout to clean
a deleted device from the DB and keeps nymead responsive during that too.

b) generally improces performance of the system by not requiring operations
(emitting events, changing states) to wait for the sync log db entry to be
made.

c) tries to fix issue #226 by rotating the DB not only when it fails to open
initially, but also when it fails to insert new entries.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Yes, but @Boernsman @myshoeshurt please test this too, it fixes lots of reports of yours I could not
necessarily reproduce like you can.
@Boernsman I'd be curious how much it improves performance on your UniPi
@myshoeshurt Please check if it fixes your broken DB on the maveo box and also if removing a garage gate with huuuge log db is not failing any more (actually should be instant now).

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A