### PR TITLE
Improve log DB housekeeping performance

### DIFF
--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -56,7 +56,7 @@ public:
 
     bool jobsRunning() const;
 
-    void setMaxLogEntries(int maxLogEntries, int overflow);
+    void setMaxLogEntries(int maxLogEntries, int trimSize);
     void clearDatabase();
 
     void logSystemEvent(const QDateTime &dateTime, bool active, Logging::LoggingLevel level = Logging::LoggingLevelInfo);
@@ -88,8 +88,9 @@ private:
 
 private slots:
     void checkDBSize();
+    void trim();
 
-    void enqueJob(DatabaseJob *job);
+    void enqueJob(DatabaseJob *job, bool priority = false);
     void processQueue();
     void handleJobFinished();
 
@@ -98,10 +99,13 @@ private:
     QString m_username;
     QString m_password;
     int m_dbMaxSize;
-    int m_overflow;
-    bool m_trimWarningPrinted = false;
+    int m_trimSize;
     int m_entryCount = 0;
     bool m_dbMalformed = false;
+
+    // When maxQueueLength is exceeded, jobs will be flagged and discarded if this source logs more events
+    int m_maxQueueLength;
+    QHash<QString, QList<DatabaseJob*>> m_flaggedJobs;
 
     QList<DatabaseJob*> m_jobQueue;
     DatabaseJob *m_currentJob = nullptr;

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -925,7 +925,7 @@ void NymeaCore::deviceManagerLoaded()
     qCDebug(dcApplication()) << "Starting housekeeping...";
     QDateTime startTime = QDateTime::currentDateTime();
     DevicesFetchJob *job = m_logger->fetchDevices();
-    connect(job, &DevicesFetchJob::finished, this, [this, job, startTime](){
+    connect(job, &DevicesFetchJob::finished, m_deviceManager, [this, job, startTime](){
         foreach (const DeviceId &deviceId, job->results()) {
             if (!m_deviceManager->findConfiguredDevice(deviceId)) {
                 qCDebug(dcApplication()) << "Cleaning stale device entries from log DB for device id" << deviceId;


### PR DESCRIPTION
Getting row count on a db with approx 200000 entries on an RPi takes
about 500ms. To avoid this, this branch keeps better track of entries
in the DB and only queries DB count if we can't calculate it ourselves.
Trimming itself takes some 150ms. To reduce those calls it changes the
threshold of when to trim the DB from a fixed value of 100 to 1% of
maxDBSize.

Last but not least, getLogEntry() calls are now prioritized over
appendLogEntry() calls in order to stay responsive to client apps even
if the DB is overloaded with a huge job queue.

If the job queue grows to over 1000 jobs, a warning is now printed
about excessive logging and logs of the same type will be discared
to avoid log flooding.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A