### PR TITLE
Disconnect all slots of nymea:core on shutdown

### DIFF
--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -207,12 +207,13 @@ void NymeaCore::init() {
 /*! Destructor of the \l{NymeaCore}. */
 NymeaCore::~NymeaCore()
 {
+    qCDebug(dcApplication()) << "Shutting down NymeaCore";
     m_logger->logSystemEvent(m_timeManager->currentDateTime(), false);
 
-    // Disconnect everything that could still spawn events
-    disconnect(m_deviceManager);
-    disconnect(m_ruleEngine);
-    disconnect(m_timeManager);
+    // Disconnect all signals/slots, we're going down now
+    m_timeManager->disconnect(this);
+    m_deviceManager->disconnect(this);
+    m_ruleEngine->disconnect(this);
 
     // At very first, cut off the outside world
     qCDebug(dcApplication) << "Shutting down \"Server Manager\"";

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -62,7 +62,7 @@ void NymeaTestBase::initTestCase()
     NymeaSettings nymeadSettings(NymeaSettings::SettingsRoleGlobal);
     nymeadSettings.clear();
 
-    QLoggingCategory::setFilterRules("*.debug=false\nTests.debug=true\nMockDevice.debug=true");
+    QLoggingCategory::setFilterRules("*.debug=false\nApplication.debug=true\nTests.debug=true\nMockDevice.debug=true");
 
     // Start the server
     qCDebug(dcTests()) << "Setting up nymea core instance";


### PR DESCRIPTION
disconnect(QObject*) only disconnects the receiver, not the sender.
Because of that it happened in some circumstances that the timerManager
was still firing events even though the ruleEngine had been destroyed
already. As the timer event was connected to nymeacore, not the ruleengine
directly, it would cause occational crashes on shutdown.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A