### PR TITLE
Delete devices before plugin destruction

### DIFF
--- a/libnymea-core/devices/devicemanagerimplementation.cpp
+++ b/libnymea-core/devices/devicemanagerimplementation.cpp
@@ -94,6 +94,7 @@ DeviceManagerImplementation::~DeviceManagerImplementation()
 
     foreach (Device *device, m_configuredDevices) {
         storeDeviceStates(device);
+        delete device;
     }
 
     foreach (DevicePlugin *plugin, m_devicePlugins) {


### PR DESCRIPTION
We want to delete devices before plugins, otherwise they might still fire signals and plugins could have lambdas connected to them.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A