### PR TITLE
Don't call thingRemoved() on the plugin in case of reconfiguring

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -402,9 +402,6 @@ ThingSetupInfo *ThingManagerImplementation::reconfigureThingInternal(Thing *thin
     }
     ParamList finalParams = buildParams(thing->thingClass().paramTypes(), params);
 
-    // first remove the thing in the plugin
-    plugin->thingRemoved(thing);
-
     // mark setup as incomplete
     thing->setSetupStatus(Thing::ThingSetupStatusInProgress, Thing::ThingErrorNoError);
 

--- a/libnymea-core/jsonrpc/statehandler.cpp
+++ b/libnymea-core/jsonrpc/statehandler.cpp
@@ -54,6 +54,7 @@ StateHandler::StateHandler(QObject *parent) :
     JsonHandler(parent)
 {
     registerEnum<Types::Unit>();
+    registerEnum<Types::IOType>();
     registerObject<State>();
     registerObject<StateType>();
 

--- a/plugins/mock/integrationpluginmock.cpp
+++ b/plugins/mock/integrationpluginmock.cpp
@@ -133,6 +133,11 @@ void IntegrationPluginMock::discoverThings(ThingDiscoveryInfo *info)
 void IntegrationPluginMock::setupThing(ThingSetupInfo *info)
 {
     if (info->thing()->thingClassId() == mockThingClassId || info->thing()->thingClassId() == autoMockThingClassId) {
+        if (m_daemons.contains(info->thing())) {
+            // We already have a daemon, seem's we're reconfiguring
+            delete m_daemons.take(info->thing());
+        }
+
         bool async = false;
         bool broken = false;
         if (info->thing()->thingClassId() == mockThingClassId) {


### PR DESCRIPTION
Reasoning:

a) Currently, the API behaves inconsistently. While reconfiguring
a "justAdd" thing, it did call thingRemoved, however, reconfiguring a thing
that uses pairing did not.

b) The old implementation did not consider childs. Reconfiguring a
justAdd thing which has childs was calling thingRemoved on the parent only
but not its childs.

c) If we'd fix this by calling thingRemoved() for all flows and childs
we'd end up in hells kitchen as we can't know about the new state of childs
after the reconfiguration, so we can't just automatically add all the childs
back ourselves, the plugin needs to do that. This in turn would mean that
childs would get new ids which then breaks rules and stuff.

So the conclusion has been to just re-run the setup and the plugin implementation
is in charge for then checking the existing childs and calling autoThingDisappeared()
as needed.

WARNING: This also implies that we need to fix some plugins which currently rely
on thingRemoved to be called for reconfiguration and might create duplicate
connections or similar now.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
