### PR TITLE
Fix conversion of values

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -1697,19 +1697,19 @@ void ThingManagerImplementation::onAutoThingDisappeared(const ThingId &thingId)
     Thing *thing = m_configuredThings.value(thingId);
 
     if (!thing) {
-        qWarning(dcThingManager) << "Received an autoThingDisappeared signal but this thing is unknown:" << thingId;
+        qCWarning(dcThingManager) << "Received an autoThingDisappeared signal but this thing is unknown:" << thingId;
         return;
     }
 
     ThingClass thingClass = m_supportedThings.value(thing->thingClassId());
 
     if (thingClass.pluginId() != plugin->pluginId()) {
-        qWarning(dcThingManager) << "Received a autoThingDisappeared signal but emitting plugin does not own the thing";
+        qCWarning(dcThingManager) << "Received a autoThingDisappeared signal but emitting plugin does not own the thing";
         return;
     }
 
     if (!thing->autoCreated()) {
-        qWarning(dcThingManager) << "Received an autoThingDisappeared signal but thing creationMethod is not CreateMothodAuto";
+        qCWarning(dcThingManager) << "Received an autoThingDisappeared signal but thing creationMethod is not CreateMothodAuto";
         return;
     }
 

--- a/libnymea/integrations/thingutils.cpp
+++ b/libnymea/integrations/thingutils.cpp
@@ -41,8 +41,7 @@ ThingUtils::ThingUtils()
 
 }
 
-/*! Verify if the given \a params matches the given \a paramTypes. Ith \a requireAll
- *  is true, all \l{ParamList}{Params} has to be valid. Returns \l{Device::DeviceError} to inform about the result.*/
+/*! Verify if the given \a params matches the given \a paramTypes.*/
 Thing::ThingError ThingUtils::verifyParams(const QList<ParamType> paramTypes, const ParamList &params)
 {
     foreach (const Param &param, params) {
@@ -52,7 +51,7 @@ Thing::ThingError ThingUtils::verifyParams(const QList<ParamType> paramTypes, co
         }
     }
     foreach (const ParamType &paramType, paramTypes) {
-        bool found = false;
+        bool found = !paramType.defaultValue().isNull();
         foreach (const Param &param, params) {
             if (paramType.id() == param.paramTypeId()) {
                 found = true;

--- a/libnymea/types/statedescriptor.cpp
+++ b/libnymea/types/statedescriptor.cpp
@@ -171,11 +171,11 @@ bool StateDescriptor::operator ==(const State &state) const
     if ((m_stateTypeId != state.stateTypeId()) || (m_thingId != state.thingId())) {
         return false;
     }
-    if (!m_stateValue.canConvert(state.value().type())) {
+    QVariant convertedValue = m_stateValue;
+    bool res = convertedValue.convert(state.value().type());
+    if (!res) {
         return false;
     }
-    QVariant convertedValue = m_stateValue;
-    convertedValue.convert(state.value().type());
     switch (m_operatorType) {
     case Types::ValueOperatorEquals:
         return convertedValue == state.value();

--- a/libnymea/types/statetype.cpp
+++ b/libnymea/types/statetype.cpp
@@ -222,6 +222,12 @@ QStringList StateType::mandatoryTypeProperties()
     return QStringList() << "id" << "name" << "displayName" << "displayNameEvent" << "type" << "defaultValue";
 }
 
+/*! Returns true if this state type has an ID, a type and a name set. */
+bool StateType::isValid() const
+{
+    return !m_id.isNull() && m_type != QVariant::Invalid && !m_name.isEmpty();
+}
+
 StateTypes::StateTypes(const QList<StateType> &other)
 {
     foreach (const StateType &st, other) {

--- a/libnymea/types/statetype.h
+++ b/libnymea/types/statetype.h
@@ -96,6 +96,8 @@ public:
     static QStringList typeProperties();
     static QStringList mandatoryTypeProperties();
 
+    bool isValid() const;
+
 private:
     StateTypeId m_id;
     QString m_name;

--- a/plugins/mock/integrationpluginmock.json
+++ b/plugins/mock/integrationpluginmock.json
@@ -98,7 +98,7 @@
                             "name": "double",
                             "displayName": "Dummy double state",
                             "displayNameEvent": "Dummy double state changed",
-                            "type": "int",
+                            "type": "double",
                             "minValue": 0,
                             "maxValue": 100,
                             "defaultValue": 2.7

--- a/tests/auto/actions/testactions.cpp
+++ b/tests/auto/actions/testactions.cpp
@@ -85,7 +85,6 @@ void TestActions::executeAction()
     params.insert("deviceId", deviceId);
     params.insert("params", actionParams);
     QVariant response = injectAndWait("Actions.ExecuteAction", params);
-    qDebug() << "executeActionresponse" << response;
     verifyError(response, "deviceError", enumValueName(error));
 
     // Fetch action execution history from mock device

--- a/tests/auto/devices/testdevices.cpp
+++ b/tests/auto/devices/testdevices.cpp
@@ -382,10 +382,10 @@ void TestDevices::addConfiguredDevice_data()
     QTest::newRow("User, JustAdd, wrong param") << mockThingClassId << invalidDeviceParams << true << Device::DeviceErrorInvalidParameter;
 
     deviceParams.clear(); deviceParams << httpportParam << fakeparam;
-    QTest::newRow("USer, JustAdd, additional invalid param") << mockThingClassId << deviceParams << false << Device::DeviceErrorNoError;
+    QTest::newRow("User, JustAdd, additional invalid param") << mockThingClassId << deviceParams << false << Device::DeviceErrorInvalidParameter;
 
     deviceParams.clear(); deviceParams << httpportParam << fakeparam2;
-    QTest::newRow("USer, JustAdd, additional param, valid but unused") << mockThingClassId << deviceParams << true << Device::DeviceErrorNoError;
+    QTest::newRow("User, JustAdd, duplicate param") << mockThingClassId << deviceParams << true << Device::DeviceErrorInvalidParameter;
 
 }
 

--- a/tests/auto/integrations/testintegrations.cpp
+++ b/tests/auto/integrations/testintegrations.cpp
@@ -382,10 +382,10 @@ void TestIntegrations::addThing_data()
     QTest::newRow("User, JustAdd, wrong param") << mockThingClassId << invalidThingParams << true << Thing::ThingErrorInvalidParameter;
 
     thingParams.clear(); thingParams << httpportParam << fakeparam;
-    QTest::newRow("USer, JustAdd, additional invalid param") << mockThingClassId << thingParams << false << Thing::ThingErrorNoError;
+    QTest::newRow("USer, JustAdd, additional invalid param") << mockThingClassId << thingParams << false << Thing::ThingErrorInvalidParameter;
 
     thingParams.clear(); thingParams << httpportParam << fakeparam2;
-    QTest::newRow("USer, JustAdd, additional param, valid but unused") << mockThingClassId << thingParams << true << Thing::ThingErrorNoError;
+    QTest::newRow("USer, JustAdd, duplicate param") << mockThingClassId << thingParams << true << Thing::ThingErrorInvalidParameter;
 
 }
 

--- a/tests/auto/rules/testrules.cpp
+++ b/tests/auto/rules/testrules.cpp
@@ -265,13 +265,14 @@ void TestRules::setWritableStateValue(const ThingId &thingId, const StateTypeId 
         QVariantList stateChangedVariants = checkNotifications(stateSpy, "Integrations.StateChanged");
         QVERIFY2(stateChangedVariants.count() == 1, "Did not get Integrations.StateChanged notification.");
 
+        qCDebug(dcTests()) << "Notification content:" << qUtf8Printable(QJsonDocument::fromVariant(stateChangedVariants).toJson());
         QVariantMap notification = stateChangedVariants.first().toMap().value("params").toMap();
         QVERIFY2(notification.contains("thingId"), "Integrations.StateChanged notification does not contain thingId");
         QVERIFY2(ThingId(notification.value("thingId").toString()) == thingId, "Integrations.StateChanged notification does not contain the correct thingId");
         QVERIFY2(notification.contains("stateTypeId"), "Integrations.StateChanged notification does not contain stateTypeId");
         QVERIFY2(StateTypeId(notification.value("stateTypeId").toString()) == stateTypeId, "Integrations.StateChanged notification does not contain the correct stateTypeId");
         QVERIFY2(notification.contains("value"), "Integrations.StateChanged notification does not contain new state value");
-        QVERIFY2(notification.value("value") == QVariant(value), "Integrations.StateChanged notification does not contain the new value");
+        QVERIFY2(notification.value("value") == QVariant(value), QString("Integrations.StateChanged notification does not contain the new value. Got: %1, Expected: %2").arg(notification.value("value").toString()).arg(QVariant(value).toString()).toUtf8());
     }
 
 }
@@ -1990,11 +1991,11 @@ void TestRules::testChildEvaluator_data()
     QTest::addColumn<bool>("trigger");
     QTest::addColumn<bool>("active");
 
-    QTest::newRow("Unchanged | 2 | 2.5 | String value 1 | #FF0000") << testThingId << ruleMap << 2 << 2.5 << "String value 1" << "#FF0000" << false << false;
-    QTest::newRow("Unchanged | 60 | 2.5 | String value 2 | #FF0000") << testThingId << ruleMap << 60 << 2.5 << "String value 2" << "#FF0000" << false << false;
-    QTest::newRow("Unchanged | 60 | 20.5 | String value 2 | #FF0000") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#FF0000" << false << false;
-    QTest::newRow("Active | 60 | 20.5 | String value 2 | #00FF00") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#00FF00" << true << true;
-    QTest::newRow("Active | 60 | 20.5 | String value 2 | #00FF00") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#00FF00" << true << true;
+    QTest::newRow("Unchanged | 2 | 2.5 | String value 1 | #FF0000") << testThingId << ruleMap << 2 << 2.5 << "String value 1" << "#ff0000" << false << false;
+    QTest::newRow("Unchanged | 60 | 2.5 | String value 2 | #FF0000") << testThingId << ruleMap << 60 << 2.5 << "String value 2" << "#ff0000" << false << false;
+    QTest::newRow("Unchanged | 60 | 20.5 | String value 2 | #FF0000") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#ff0000" << false << false;
+    QTest::newRow("Active | 60 | 20.5 | String value 2 | #00FF00") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#00ff00" << true << true;
+    QTest::newRow("Active | 60 | 20.5 | String value 2 | #00FF00") << testThingId << ruleMap << 60 << 20.5 << "String value 2" << "#00ff00" << true << true;
 }
 
 void TestRules::testChildEvaluator()

--- a/tests/testlib/nymeatestbase.h
+++ b/tests/testlib/nymeatestbase.h
@@ -118,7 +118,7 @@ protected:
     // just for debugging
     inline void printJson(const QVariant &response) {
         QJsonDocument jsonDoc = QJsonDocument::fromVariant(response);
-        qDebug() << jsonDoc.toJson();
+        qCDebug(dcTests()) << jsonDoc.toJson();
     }
 
     void waitForDBSync();


### PR DESCRIPTION
This fixes 4 issues in regard to types of values:

1) Default values for params in the metadata were not converted properly,
most visibly on integer values being loaded as double values.

2) Param values coming in from jsonrpc were not converted properly.

3) The plugin might set state values with invalid types or being out of range.

4) If, for some reason (e.g. earlier versions of nymea, or a plugin setting
its own params in code with a wrong type), there was a param value with a
wrong type in the system, we stored that wrong type and restored it on loading
of plugin params while instead it really should be converted to the specified
type in the ParamType.



nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
On it

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A