### PR TITLE
Use bindValue for composing query strings for the log DB

### DIFF
--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -372,18 +372,19 @@ void LogEngine::removeRuleLogs(const RuleId &ruleId)
 
 void LogEngine::appendLogEntry(const LogEntry &entry)
 {
-    QString queryString = QString("INSERT INTO entries (timestamp, loggingEventType, loggingLevel, sourceType, typeId, thingId, value, active, errorCode) values ('%1', '%2', '%3', '%4', '%5', '%6', '%7', '%8', '%9');")
-            .arg(entry.timestamp().toMSecsSinceEpoch())
-            .arg(entry.eventType())
-            .arg(entry.level())
-            .arg(entry.source())
-            .arg(entry.typeId().toString())
-            .arg(entry.thingId().toString())
-            .arg(entry.value().toString())
-            .arg(entry.active())
-            .arg(entry.errorCode());
+    QString queryString = QString("INSERT INTO entries (timestamp, loggingEventType, loggingLevel, sourceType, typeId, thingId, value, active, errorCode) values (?, ?, ?, ?, ?, ?, ?, ?, ?);");
+    QVariantList bindValues;
+    bindValues.append(entry.timestamp().toMSecsSinceEpoch());
+    bindValues.append(entry.eventType());
+    bindValues.append(entry.level());
+    bindValues.append(entry.source());
+    bindValues.append(entry.typeId().toString());
+    bindValues.append(entry.thingId().toString());
+    bindValues.append(entry.value());
+    bindValues.append(entry.active());
+    bindValues.append(entry.errorCode());
 
-    DatabaseJob *job = new DatabaseJob(m_db, queryString);
+    DatabaseJob *job = new DatabaseJob(m_db, queryString, bindValues);
 
     // Check for log flooding. If we are exceeding the queue we'll start flagging log events of a certain type.
     // If we'll get more log events of the same type while the queue is still exceededd, we'll discard the old
@@ -508,7 +509,7 @@ void LogEngine::processQueue()
         QSqlQuery query(job->m_db);
         query.prepare(job->m_queryString);
 
-        foreach (const QString &value, job->m_bindValues) {
+        foreach (const QVariant &value, job->m_bindValues) {
             query.addBindValue(value);
         }
 

--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -372,6 +372,7 @@ void LogEngine::removeRuleLogs(const RuleId &ruleId)
 
 void LogEngine::appendLogEntry(const LogEntry &entry)
 {
+    qCDebug(dcLogEngine()) << "Adding log entry:" << entry;
     QString queryString = QString("INSERT INTO entries (timestamp, loggingEventType, loggingLevel, sourceType, typeId, thingId, value, active, errorCode) values (?, ?, ?, ?, ?, ?, ?, ?, ?);");
     QVariantList bindValues;
     bindValues.append(entry.timestamp().toMSecsSinceEpoch());
@@ -380,7 +381,7 @@ void LogEngine::appendLogEntry(const LogEntry &entry)
     bindValues.append(entry.source());
     bindValues.append(entry.typeId().toString());
     bindValues.append(entry.thingId().toString());
-    bindValues.append(entry.value());
+    bindValues.append(LogValueTool::convertVariantToString(entry.value()));
     bindValues.append(entry.active());
     bindValues.append(entry.errorCode());
 

--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -127,7 +127,7 @@ class DatabaseJob: public QObject
 {
     Q_OBJECT
 public:
-    DatabaseJob(const QSqlDatabase &db, const QString &queryString, const QStringList &bindValues = QStringList()):
+    DatabaseJob(const QSqlDatabase &db, const QString &queryString, const QVariantList &bindValues = QVariantList()):
         m_db(db),
         m_queryString(queryString),
         m_bindValues(bindValues)
@@ -144,7 +144,7 @@ signals:
 private:
     QSqlDatabase m_db;
     QString m_queryString;
-    QStringList m_bindValues;
+    QVariantList m_bindValues;
 
     QString m_executedQuery;
     QSqlError m_error;

--- a/libnymea-core/logging/logfilter.cpp
+++ b/libnymea-core/logging/logfilter.cpp
@@ -182,7 +182,7 @@ void LogFilter::addValue(const QString &value)
 }
 
 /*! Returns the list of values from this \l{LogFilter}. */
-QList<QString> LogFilter::values() const
+QVariantList LogFilter::values() const
 {
     return m_values;
 }
@@ -393,7 +393,7 @@ QString LogFilter::createValuesString() const
             query.append("value = ? ");
         } else {
             query.append("( ");
-            foreach (const QString &value, m_values) {
+            foreach (const QVariant &value, m_values) {
                 query.append("value = ? ");
                 if (value != m_values.last())
                     query.append("OR ");

--- a/libnymea-core/logging/logfilter.h
+++ b/libnymea-core/logging/logfilter.h
@@ -69,7 +69,7 @@ public:
 
     // Valid for LoggingSourceStates
     void addValue(const QString &value);
-    QList<QString> values() const;
+    QVariantList values() const;
 
     void setLimit(int limit);
     int limit() const;
@@ -86,7 +86,7 @@ private:
     QList<Logging::LoggingEventType> m_eventTypes;
     QList<QUuid> m_typeIds;
     QList<ThingId> m_thingIds;
-    QList<QString> m_values;
+    QVariantList m_values;
     int m_limit = -1;
     int m_offset = 0;
 

--- a/libnymea-core/logging/logvaluetool.cpp
+++ b/libnymea-core/logging/logvaluetool.cpp
@@ -44,7 +44,6 @@ QString LogValueTool::convertVariantToString(const QVariant &value)
     switch (value.type()) {
     case QVariant::Double:
         return QString::number(value.toDouble());
-        break;
     case QVariant::List: {
         QStringList valueStringList;
         foreach (const QVariant &variantValue, value.toList()) {
@@ -54,7 +53,6 @@ QString LogValueTool::convertVariantToString(const QVariant &value)
     }
     default:
         return value.toString();
-        break;
     }
 }
 


### PR DESCRIPTION
Event/action param values might not be escaped properly otherwise.

For instance, listening to "Sweet Child O' Mine" would break the query as `'` terminates it.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A