### PR TITLE
Fix missing name method override for json handlers

### DIFF
--- a/libnymea-core/jsonrpc/actionhandler.h
+++ b/libnymea-core/jsonrpc/actionhandler.h
@@ -42,7 +42,7 @@ class ActionHandler : public JsonHandler
 public:
     explicit ActionHandler(QObject *parent = nullptr);
 
-    QString name() const;
+    QString name() const override;
 
     Q_INVOKABLE JsonReply *ExecuteAction(const QVariantMap &params, const JsonContext &context);
     Q_INVOKABLE JsonReply *GetActionType(const QVariantMap &params, const JsonContext &context) const;

--- a/libnymea-core/jsonrpc/configurationhandler.h
+++ b/libnymea-core/jsonrpc/configurationhandler.h
@@ -44,7 +44,7 @@ class ConfigurationHandler : public JsonHandler
 
 public:
     ConfigurationHandler(QObject *parent = nullptr);
-    QString name() const;
+    QString name() const override;
 
     Q_INVOKABLE JsonReply *GetConfigurations(const QVariantMap &params) const;
     Q_INVOKABLE JsonReply *GetTimeZones(const QVariantMap &params) const;

--- a/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
+++ b/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
@@ -56,7 +56,7 @@ public:
     JsonRPCServerImplementation(const QSslConfiguration &sslConfiguration = QSslConfiguration(), QObject *parent = nullptr);
 
     // JsonHandler API implementation
-    QString name() const;
+    QString name() const override;
     Q_INVOKABLE JsonReply *Hello(const QVariantMap &params, const JsonContext &context);
     Q_INVOKABLE JsonReply *Introspect(const QVariantMap &params) const;
     Q_INVOKABLE JsonReply *Version(const QVariantMap &params) const;

--- a/libnymea-core/jsonrpc/networkmanagerhandler.h
+++ b/libnymea-core/jsonrpc/networkmanagerhandler.h
@@ -44,7 +44,7 @@ class NetworkManagerHandler : public JsonHandler
 public:
     explicit NetworkManagerHandler(NetworkManager *networkManager, QObject *parent = nullptr);
 
-    QString name() const;
+    QString name() const override;
 
     Q_INVOKABLE JsonReply *GetNetworkStatus(const QVariantMap &params);
     Q_INVOKABLE JsonReply *EnableNetworking(const QVariantMap &params);


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
