### PR TITLE
Fix update busy flag in GetUpdateStatus API call

### DIFF
--- a/libnymea-core/jsonrpc/systemhandler.cpp
+++ b/libnymea-core/jsonrpc/systemhandler.cpp
@@ -319,7 +319,7 @@ JsonReply *SystemHandler::GetUpdateStatus(const QVariantMap &params) const
 {
     Q_UNUSED(params)
     QVariantMap ret;
-    ret.insert("busy", m_platform->updateController()->updateRunning());
+    ret.insert("busy", m_platform->updateController()->busy());
     ret.insert("updateRunning", m_platform->updateController()->updateRunning());
     return createReply(ret);
 }


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
