### PR TITLE
Add a command line argument for additional server interfaces

### DIFF
--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -78,7 +78,7 @@ NymeaCore::NymeaCore(QObject *parent) :
 {
 }
 
-void NymeaCore::init() {
+void NymeaCore::init(const QStringList &additionalInterfaces) {
     qCDebug(dcCore()) << "Initializing NymeaCore";
 
     qCDebug(dcPlatform()) << "Loading platform abstraction";
@@ -104,7 +104,7 @@ void NymeaCore::init() {
     m_userManager = new UserManager(NymeaSettings::settingsPath() + "/user-db.sqlite", this);
 
     qCDebug(dcCore) << "Creating Server Manager";
-    m_serverManager = new ServerManager(m_platform, m_configuration, this);
+    m_serverManager = new ServerManager(m_platform, m_configuration, additionalInterfaces, this);
 
     qCDebug(dcCore) << "Creating Hardware Manager";
     m_hardwareManager = new HardwareManagerImplementation(m_platform, m_serverManager->mqttBroker(), this);

--- a/libnymea-core/nymeacore.h
+++ b/libnymea-core/nymeacore.h
@@ -76,7 +76,7 @@ public:
     static NymeaCore* instance();
     ~NymeaCore();
 
-    void init();
+    void init(const QStringList &additionalInterfaces = QStringList());
     void destroy();
 
     // Thing handling

--- a/libnymea-core/servermanager.h
+++ b/libnymea-core/servermanager.h
@@ -57,7 +57,7 @@ class ServerManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit ServerManager(Platform *platform, NymeaConfiguration *configuration, QObject *parent = nullptr);
+    explicit ServerManager(Platform *platform, NymeaConfiguration *configuration, const QStringList &additionalInterfaces = QStringList(), QObject *parent = nullptr);
 
     // Interfaces
     JsonRPCServerImplementation *jsonServer() const;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -126,6 +126,9 @@ int main(int argc, char *argv[])
     QCommandLineOption debugOption(QStringList() << "d" << "debug-category", debugDescription, "[No]DebugCategory[Warnings]");
     parser.addOption(debugOption);
 
+    QCommandLineOption interfacesOption({"i", "interface"}, QCoreApplication::translate("nymea", "Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777)."));
+    parser.addOption(interfacesOption);
+
     parser.process(application);
 
     // Open the logfile, if any specified
@@ -216,7 +219,7 @@ int main(int argc, char *argv[])
         }
 
         // create core instance
-        NymeaCore::instance()->init();
+        NymeaCore::instance()->init(parser.values(interfacesOption));
         int ret = application.exec();
         closeLogFile();
         return ret;


### PR DESCRIPTION
This is needed to allow running unit tests on other packages in a more reliable way. For example we have unit tests on some experience plugins but can't run them reliably in jenkins.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
