### PR TITLE
Don't use deprecated QString::sprintf and qVariantFromValue

### DIFF
--- a/libnymea/coap/coapobserveresource.cpp
+++ b/libnymea/coap/coapobserveresource.cpp
@@ -55,13 +55,6 @@ CoapObserveResource::CoapObserveResource(const QUrl &url, const QByteArray &toke
 {
 }
 
-/*! Constructs a copy of the given \a other \l{CoapObserveResource}. */
-CoapObserveResource::CoapObserveResource(const CoapObserveResource &other)
-{
-    m_url = other.url();
-    m_token = other.token();
-}
-
 /*! Returns the url of this \l{CoapObserveResource}. */
 QUrl CoapObserveResource::url() const
 {

--- a/libnymea/coap/coapobserveresource.h
+++ b/libnymea/coap/coapobserveresource.h
@@ -42,7 +42,6 @@ class LIBNYMEA_EXPORT CoapObserveResource
 public:
     CoapObserveResource();
     CoapObserveResource(const QUrl &url, const QByteArray &token);
-    CoapObserveResource(const CoapObserveResource &other);
 
     QUrl url() const;
     QByteArray token() const;

--- a/server/nymeaapplication.cpp
+++ b/server/nymeaapplication.cpp
@@ -76,7 +76,7 @@ static void printBacktrace()
     size_t funktionNameSize = 256;
     char* functionName = (char*)malloc(funktionNameSize);
     for (int i = 1; i < traceLength; i++) {
-        QString address = QString().sprintf("%p", trace[i]);
+        QString address = QString::asprintf("%p", trace[i]);
         QString fileName = QString(symbolList[i]);
         int fileIndex = fileName.indexOf("(");
         QString lineCommand = QString("addr2line %1 -e %2").arg(address).arg(fileName.left(fileIndex));
@@ -110,9 +110,9 @@ static void printBacktrace()
             char* ret = abi::__cxa_demangle(begin_name, functionName, &funktionNameSize, &status);
             if (status == 0) {
                 functionName = ret;
-                functionString = QString("    %1").arg(QString().sprintf("%s+%s", functionName, begin_offset));
+                functionString = QString("    %1").arg(QString::asprintf("%s+%s", functionName, begin_offset));
             } else {
-                functionString = QString("    %1").arg(QString().sprintf("%s()+%s", begin_name, begin_offset));
+                functionString = QString("    %1").arg(QString::asprintf("%s()+%s", begin_name, begin_offset));
             }
         }
 

--- a/tests/utils/pushbuttonagent.cpp
+++ b/tests/utils/pushbuttonagent.cpp
@@ -42,7 +42,7 @@ bool PushButtonAgent::init(QDBusConnection::BusType busType)
     }
 
     QDBusMessage message = QDBusMessage::createMethodCall("io.guh.nymead", "/io/guh/nymead/UserManager", "io.guh.nymead", "RegisterButtonAgent");
-    message << qVariantFromValue(QDBusObjectPath("/nymea/pushbuttonhandler"));
+    message << QVariant::fromValue(QDBusObjectPath("/nymea/pushbuttonhandler"));
     QDBusMessage reply = bus.call(message);
     if (!reply.errorName().isEmpty()) {
         qCWarning(dcPushButtonAgent()) << "Error registering PushButton agent:" << reply.errorMessage();


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
