### PR TITLE
Drop the manually created -dbg package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -86,23 +86,6 @@ Description: An open source IoT server - daemon
  .
  This package will install the daemon.
 
-Package: nymea-dbg
-Priority: extra
-Architecture: any
-Section: debug
-Multi-Arch: same
-Depends: nymea (= ${binary:Version}),
-         ${misc:Depends}
-Replaces: guh-dbg
-Description: An open source IoT server - debug symbols
- The nymea daemon is a plugin based IoT (Internet of Things) server. The
- server works like a translator for devices, things and services and
- allows them to interact.
- With the powerful rule engine you are able to connect any device available
- in the system and create individual scenes and behaviors for your environment.
- .
- This package provides all debug symbols for nymea.
-
 
 Package: nymea-doc
 Section: doc

--- a/debian/rules
+++ b/debian/rules
@@ -49,9 +49,6 @@ override_dh_install: $(PREPROCESS_FILES:.in=)
 override_dh_auto_test:
 	dh_auto_test -- -k TESTARGS="-m 120 -p -o -p -,txt -p -o -p test-results.xml,xunitxml" TESTRUNNER="dbus-test-runner --bus-type=both --task"
 
-override_dh_strip:
-	dh_strip --dbg-package=nymea-dbg
-
 override_dh_auto_clean:
 	dh_auto_clean
 	find . -name *.qm -exec rm {} \;


### PR DESCRIPTION
We'll activate autodbgsym in crossbuilder instead

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
