### PR TITLE
Increase the maximum allowed message size in JSONRPC

### DIFF
--- a/libnymea-core/jsonrpc/jsonrpcserverimplementation.cpp
+++ b/libnymea-core/jsonrpc/jsonrpcserverimplementation.cpp
@@ -621,8 +621,8 @@ void JsonRPCServerImplementation::processData(const QUuid &clientId, const QByte
     }
     m_clientBuffers[clientId] = buffer;
 
-    if (buffer.size() > 1024 * 10) {
-        qCWarning(dcJsonRpc()) << "Client buffer larger than 10KB and no valid data. Dropping client connection.";
+    if (buffer.size() > 1024 * 1024) {
+        qCWarning(dcJsonRpc()) << "Client buffer larger than 1MB and no valid data. Dropping client connection.";
         interface->terminateClientConnection(clientId);
     }
 }

--- a/tests/auto/jsonrpc/testjsonrpc.cpp
+++ b/tests/auto/jsonrpc/testjsonrpc.cpp
@@ -1379,7 +1379,7 @@ void TestJSONRPC::testGarbageData()
     QSignalSpy spy(m_mockTcpServer, &MockTcpServer::connectionTerminated);
 
     QByteArray data;
-    for (int i = 0; i < 1024; i++) {
+    for (int i = 0; i < 1024 * 1024; i++) {
         data.append("a");
     }
     for (int i = 0; i < 11 && spy.count() == 0; i ++) {


### PR DESCRIPTION
Turns out 10KB can be exceeded with scripting

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
N/A

Did you update translations (cd builddir && make lupdate)?
N/A

