### PR TITLE
Allow building the plugininfocompiler standalone

### DIFF
--- a/libnymea-core/libnymea-core.pro
+++ b/libnymea-core/libnymea-core.pro
@@ -3,7 +3,7 @@ TARGET = nymea-core
 
 include(../nymea.pri)
 
-QT += sql qml
+QT += bluetooth dbus qml sql websockets
 INCLUDEPATH += $$top_srcdir/libnymea $$top_builddir
 LIBS += -L$$top_builddir/libnymea/ -lnymea -lssl -lcrypto
 

--- a/libnymea/integrations/pluginmetadata.cpp
+++ b/libnymea/integrations/pluginmetadata.cpp
@@ -759,8 +759,6 @@ void PluginMetadata::parse(const QJsonObject &jsonObject)
     }
     if (!hasError) {
         m_isValid = true;
-    } else {
-        qCWarning(dcPluginMetadata()) << "Device metadata has errors.";
     }
 }
 
@@ -783,7 +781,6 @@ QPair<bool, Types::Unit> PluginMetadata::loadAndVerifyUnit(const QString &unitSt
 
     // inform the plugin developer about the error in the plugin json file
     if (enumValue == -1) {
-        qCWarning(dcPluginMetadata()) << QString("\"%1\" plugin:").arg(pluginName()).toLatin1().data() << QString("Invalid unit type \"%1\" in json file.").arg(unitString).toLatin1().data();
         return QPair<bool, Types::Unit>(false, Types::UnitNone);
     }
 
@@ -873,7 +870,7 @@ QPair<bool, ParamTypes> PluginMetadata::parseParamTypes(const QJsonArray &array)
         if (pt.contains("inputType")) {
             QPair<bool, Types::InputType> inputTypeVerification = loadAndVerifyInputType(pt.value("inputType").toString());
             if (!inputTypeVerification.first) {
-                qCWarning(dcPluginMetadata()) << pluginName() << QString("Invalid inputType for paramType") << pt;
+                m_validationErrors.append("Param type \"" + paramName + "\" has invalid inputType \"" + pt.value("type").toString() + "\"");
                 hasErrors = true;
             } else {
                 paramType.setInputType(inputTypeVerification.second);
@@ -884,7 +881,7 @@ QPair<bool, ParamTypes> PluginMetadata::parseParamTypes(const QJsonArray &array)
         if (pt.contains("unit")) {
             QPair<bool, Types::Unit> unitVerification = loadAndVerifyUnit(pt.value("unit").toString());
             if (!unitVerification.first) {
-                qCWarning(dcPluginMetadata()) << pluginName() << QString("Invalid unit type for paramType") << pt;
+                m_validationErrors.append("Param type \"" + paramName + "\" has invalid unit \"" + pt.value("type").toString() + "\"");
                 hasErrors = true;
             } else {
                 paramType.setUnit(unitVerification.second);
@@ -935,7 +932,6 @@ QPair<bool, Types::InputType> PluginMetadata::loadAndVerifyInputType(const QStri
 
     // inform the plugin developer about the error in the plugin json file
     if (enumValue == -1) {
-        qCWarning(dcPluginMetadata()) << QString("\"%1\" plugin:").arg(pluginName()).toLatin1().data() << QString("Invalid inputType \"%1\" in json file.").arg(inputType).toLatin1().data();
         return QPair<bool, Types::InputType>(false, Types::InputTypeNone);
     }
 
@@ -949,7 +945,9 @@ bool PluginMetadata::verifyDuplicateUuid(const QUuid &uuid)
         if (m_strictRun) {
             return false;
         } else {
-            qCWarning(dcPluginMetadata()) << "THIS PLUGIN USES DUPLICATE UUID" << uuid.toString() << "! THIS IS NOT SUPPORTED AND MAY CAUSE RUNTIME ISSUES.";
+            // Using regular qWarning here as I'm struggling with making the nymea debug categories work in a pic only build
+            // This is only used in special cirumstances and it's probably ok that one cannot filter away this warning
+            qWarning() << "THIS PLUGIN USES DUPLICATE UUID" << uuid.toString() << "! THIS IS NOT SUPPORTED AND MAY CAUSE RUNTIME ISSUES.";
         }
     }
     if (m_currentScopUuids.contains(uuid)) {

--- a/libnymea/loggingcategories.cpp
+++ b/libnymea/loggingcategories.cpp
@@ -37,7 +37,6 @@
 QStringList s_nymeaLoggingCategories;
 
 // FIXME: Those should eventually disappear from here
-NYMEA_LOGGING_CATEGORY(dcPluginMetadata, "PluginMetadata")
 NYMEA_LOGGING_CATEGORY(dcThing, "Thing")
 NYMEA_LOGGING_CATEGORY(dcThingManager, "ThingManager")
 NYMEA_LOGGING_CATEGORY(dcSystem, "System")

--- a/libnymea/loggingcategories.h
+++ b/libnymea/loggingcategories.h
@@ -49,7 +49,6 @@ extern QStringList s_nymeaLoggingCategories;
     } \
 
 // FIXME: Those should eventually disappear from here
-Q_DECLARE_LOGGING_CATEGORY(dcPluginMetadata)
 Q_DECLARE_LOGGING_CATEGORY(dcThing)
 Q_DECLARE_LOGGING_CATEGORY(dcThingManager)
 Q_DECLARE_LOGGING_CATEGORY(dcSystem)

--- a/nymea.pri
+++ b/nymea.pri
@@ -3,8 +3,6 @@ COPYRIGHT_YEAR_TO=2020
 
 DEFINES += COPYRIGHT_YEAR_STRING=\\\"$${COPYRIGHT_YEAR_FROM}-$${COPYRIGHT_YEAR_TO}\\\"
 
-QT *= network websockets bluetooth dbus
-
 QMAKE_CXXFLAGS *= -Werror -std=c++11 -g
 QMAKE_LFLAGS *= -std=c++11
 

--- a/nymea.pro
+++ b/nymea.pro
@@ -17,13 +17,14 @@ QMAKE_SUBSTITUTES += version.h.in
 
 TEMPLATE=subdirs
 
-SUBDIRS += libnymea tools
-tools.depends = libnymea
-
-minimal {
+piconly {
+    message("Plugininfocompiler build. Only nymea-plugininfocompiler will be built.")
+    SUBDIRS += tools
+} else:minimal {
     message("Minimal build. Only libraries required to build nymea-plugins will be built.")
+    SUBDIRS += libnymea tools
 } else {
-    SUBDIRS += server libnymea-core plugins
+    SUBDIRS += libnymea server libnymea-core plugins tools
     libnymea-core.depends = libnymea
     plugins.depends = libnymea tools
     server.depends = libnymea libnymea-core plugins

--- a/server/server.pro
+++ b/server/server.pro
@@ -8,7 +8,7 @@ INCLUDEPATH += ../libnymea ../libnymea-core $$top_builddir
 target.path = /usr/bin
 INSTALLS += target
 
-QT *= sql xml websockets bluetooth dbus network
+QT += sql xml websockets bluetooth dbus network
 
 LIBS += -L$$top_builddir/libnymea/ -lnymea \
         -L$$top_builddir/libnymea-core -lnymea-core \

--- a/tests/auto/autotests.pri
+++ b/tests/auto/autotests.pri
@@ -1,4 +1,4 @@
-QT += testlib network sql
+QT += dbus testlib network sql websockets
 CONFIG += testcase
 
 INCLUDEPATH += $$top_srcdir/libnymea \

--- a/tests/testlib/testlib.pro
+++ b/tests/testlib/testlib.pro
@@ -3,7 +3,7 @@ TARGET = nymea-testlib
 
 include(../../nymea.pri)
 
-QT += testlib network sql
+QT += testlib dbus network sql websockets
 
 INCLUDEPATH += $$top_srcdir/libnymea \
                $$top_srcdir/libnymea-core

--- a/tools/nymea-plugininfocompiler/nymea-plugininfocompiler.pro
+++ b/tools/nymea-plugininfocompiler/nymea-plugininfocompiler.pro
@@ -4,14 +4,52 @@ CONFIG -= app_bundle
 
 include(../../nymea.pri)
 INCLUDEPATH += $$top_srcdir/libnymea $$top_builddir
-LIBS += -L$$top_builddir/libnymea -lnymea
+
+# FIXME: Rebuilding types here so that we can build the nymea-plugininfocompiler
+# without having to build the entire libnymea
+# Libnymea needs to be split up into 2 parts, one with full hardaremanager support
+# the other with something more minimalistic that doesn't pull in Bluetooth, ZigBee,
+# MQTT and whatnot.
 
 SOURCES += \
-        main.cpp \
-    plugininfocompiler.cpp
+    main.cpp \
+    plugininfocompiler.cpp \
+    $$top_srcdir/libnymea/integrations/pluginmetadata.cpp \
+    $$top_srcdir/libnymea/integrations/thingutils.cpp \
+    $$top_srcdir/libnymea/types/paramtype.cpp \
+    $$top_srcdir/libnymea/types/param.cpp \
+    $$top_srcdir/libnymea/types/vendor.cpp \
+    $$top_srcdir/libnymea/types/thingclass.cpp \
+    $$top_srcdir/libnymea/types/statetype.cpp \
+    $$top_srcdir/libnymea/types/eventtype.cpp \
+    $$top_srcdir/libnymea/types/actiontype.cpp \
+    $$top_srcdir/libnymea/types/interface.cpp \
+    $$top_srcdir/libnymea/types/interfacestatetype.cpp \
+    $$top_srcdir/libnymea/types/interfaceeventtype.cpp \
+    $$top_srcdir/libnymea/types/interfaceactiontype.cpp \
+    $$top_srcdir/libnymea/loggingcategories.cpp \
 
 HEADERS += \
-    plugininfocompiler.h
+    plugininfocompiler.h \
+    $$top_srcdir/libnymea/typeutils.h \
+    $$top_srcdir/libnymea/integrations/pluginmetadata.h \
+    $$top_srcdir/libnymea/integrations/thingutils.h \
+    $$top_srcdir/libnymea/types/paramtype.h \
+    $$top_srcdir/libnymea/types/param.h \
+    $$top_srcdir/libnymea/types/vendor.h \
+    $$top_srcdir/libnymea/types/thingclass.h \
+    $$top_srcdir/libnymea/types/statetype.h \
+    $$top_srcdir/libnymea/types/eventtype.h \
+    $$top_srcdir/libnymea/types/actiontype.h \
+    $$top_srcdir/libnymea/types/interface.h \
+    $$top_srcdir/libnymea/types/interfacestatetype.h \
+    $$top_srcdir/libnymea/types/interfaceeventtype.h \
+    $$top_srcdir/libnymea/types/interfaceactiontype.h \
+    $$top_srcdir/libnymea/loggingcategories.h \
+
+RESOURCES += \
+    $$top_srcdir/libnymea/interfaces/interfaces.qrc
+
 
 target.path = $$[QT_INSTALL_PREFIX]/bin
 INSTALLS += target


### PR DESCRIPTION
This is required to be able to build a "native" version of the pic
without having to build all the dependencies pulled in by the
HardwareManager.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
