### PR TITLE
Fix memory off-by-one overflow

### DIFF
--- a/libnymea-core/integrations/python/pynymealogginghandler.h
+++ b/libnymea-core/integrations/python/pynymealogginghandler.h
@@ -28,8 +28,7 @@ static int PyNymeaLoggingHandler_init(PyNymeaLoggingHandler *self, PyObject *arg
         return -1;
     }
 
-    self->category = (char*)malloc(qstrlen(category));
-    qstrcpy(self->category, category);
+    self->category = qstrdup(category);
 
     return 0;
 }
@@ -37,7 +36,7 @@ static int PyNymeaLoggingHandler_init(PyNymeaLoggingHandler *self, PyObject *arg
 static void PyNymeaLoggingHandler_dealloc(PyNymeaLoggingHandler * self)
 {
     qCDebug(dcPythonIntegrations()) << "--- PyNymeaLoggingHandler";
-    free(self->category);
+    delete[] self->category;
     Py_TYPE(self)->tp_free(self);
 }
 

--- a/libnymea-core/integrations/python/pystdouthandler.h
+++ b/libnymea-core/integrations/python/pystdouthandler.h
@@ -30,9 +30,8 @@ static int PyStdOutHandler_init(PyStdOutHandler *self, PyObject *args, PyObject 
         return -1;
     }
 
-    self->category = (char*)malloc(qstrlen(category));
+    self->category = qstrdup(category);
     self->msgType = msgType;
-    qstrcpy(self->category, category);
 
     return 0;
 }
@@ -40,7 +39,7 @@ static int PyStdOutHandler_init(PyStdOutHandler *self, PyObject *args, PyObject 
 static void PyStdOutHandler_dealloc(PyStdOutHandler * self)
 {
     qCDebug(dcPythonIntegrations()) << "--- PyStdOutHandler";
-    free(self->category);
+    delete[] self->category;
     Py_TYPE(self)->tp_free(self);
 }
 


### PR DESCRIPTION
Null-termination was overflowing allocated buffer.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
Y

Did you update the documentation?
Y

Did you update translations (cd builddir && make lupdate)?
Y
