### PR TITLE
Silence plugin dir debug print

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -165,7 +165,6 @@ QList<QJsonObject> ThingManagerImplementation::pluginsMetadata()
 
     foreach (const QString &path, searchDirs) {
         QDir dir(path);
-        qCDebug(dcThingManager) << "Loading plugins from:" << dir.absolutePath();
         foreach (const QString &entry, dir.entryList({"*.so", "*.js", "*.py"}, QDir::Files)) {
 
             QFileInfo fi(path + '/' + entry);


### PR DESCRIPTION
This is printed before logging filters are set because it's needed
for generating the --help text. There shouldn't be a debug print at
this place yet.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
