### PR TITLE
Restructure nymea-sdk meta package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -184,7 +184,7 @@ Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libnymea1-dev (= ${binary:Version}),
+         libnymea1 (= ${binary:Version}),
          qttools5-dev-tools,
          rsync,
 Description: Tools for developing nymea plugins.

--- a/debian/control
+++ b/debian/control
@@ -184,7 +184,7 @@ Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends},
          ${misc:Depends},
-         libnymea1 (= ${binary:Version}),
+         libnymea1-dev (= ${binary:Version}),
          qttools5-dev-tools,
          rsync,
 Description: Tools for developing nymea plugins.
@@ -195,10 +195,9 @@ Package: nymea-sdk
 Section: devel
 Architecture: all
 Multi-Arch: allowed
-Depends: crossbuilder,
-         libnymea1-dev,
-         nymea-dev-tools,
-         nymea-qtcreator-wizards,
+Depends: nymea-dev-tools
+Recommends: nymea-qtcreator-wizards,
+            crossbuilder,
 Description: The nymea SDK.
  .
  Meta-Package for everything required to develop on nymea.

--- a/debian/libnymea1-dev.install.in
+++ b/debian/libnymea1-dev.install.in
@@ -1,4 +1,12 @@
 usr/lib/@DEB_HOST_MULTIARCH@/libnymea.so
-usr/include/nymea/* usr/include/nymea
-libnymea/integrations/plugin.pri usr/include/nymea/
+usr/include/nymea/*.h
+usr/include/nymea/coap/*
+usr/include/nymea/experiences/*
+usr/include/nymea/hardware/*
+usr/include/nymea/integrations/*
+usr/include/nymea/jsonrpc/*
+usr/include/nymea/network/*
+usr/include/nymea/platform/*
+usr/include/nymea/time/*
+usr/include/nymea/types/*
 usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/nymea.pc

--- a/debian/nymea-dev-tools.install.in
+++ b/debian/nymea-dev-tools.install.in
@@ -1,1 +1,2 @@
 usr/bin/nymea-plugininfocompiler
+usr/include/nymea/plugin.pri


### PR DESCRIPTION
nymea-dev-tools depending on libnymea1-dev now, given it requires
the plugin.pri for translations support at least.

Instead, make the dependency to QtCreator related stuff optional (recommended).

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
