### PR TITLE
Allow calling ScriptAction::execute() without parameters

### DIFF
--- a/libnymea-core/scriptengine/scriptaction.h
+++ b/libnymea-core/scriptengine/scriptaction.h
@@ -33,6 +33,7 @@
 
 #include <QObject>
 #include <QQmlParserStatus>
+#include <QVariantMap>
 
 class ThingManager;
 
@@ -65,7 +66,7 @@ public:
     void setActionName(const QString &actionName);
 
 public slots:
-    void execute(const QVariantMap &params);
+    void execute(const QVariantMap &params = QVariantMap());
 
 signals:
     void thingIdChanged();


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
