### PR TITLE
Don't call thingRemoved() when a thing didn't complete the setup

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -772,6 +772,11 @@ ThingSetupInfo* ThingManagerImplementation::addConfiguredThingInternal(const Thi
 
 Thing::ThingError ThingManagerImplementation::removeConfiguredThing(const ThingId &thingId)
 {
+    // We're checking thingSetupStatus and abort any pending setup here. As setup finished()
+    // comes in as a QueuedConnection, make sure to process all events before going on so we
+    // don't end up aborting an already finished setup instead of calling thingRemoved() on it.
+    qApp->processEvents();
+
     Thing *thing = m_configuredThings.take(thingId);
     if (!thing) {
         return Thing::ThingErrorThingNotFound;
@@ -779,11 +784,12 @@ Thing::ThingError ThingManagerImplementation::removeConfiguredThing(const ThingI
     IntegrationPlugin *plugin = m_integrationPlugins.value(thing->pluginId());
     if (!plugin) {
         qCWarning(dcThingManager()).nospace() << "Plugin not loaded for thing " << thing->name() << ". Not calling thingRemoved on plugin.";
-    } else if (thing->setupStatus() == Thing::ThingSetupStatusComplete) {
-        plugin->thingRemoved(thing);
     } else if (thing->setupStatus() == Thing::ThingSetupStatusInProgress) {
+        qCWarning(dcThingManager()).nospace() << "Thing " << thing->name() << " is still being set up. Aborting setup.";
         ThingSetupInfo *setupInfo = m_pendingSetups.value(thingId);
         emit setupInfo->aborted();
+    } else if (thing->setupStatus() == Thing::ThingSetupStatusComplete) {
+        plugin->thingRemoved(thing);
     }
 
     thing->deleteLater();

--- a/libnymea-core/integrations/thingmanagerimplementation.h
+++ b/libnymea-core/integrations/thingmanagerimplementation.h
@@ -191,6 +191,7 @@ private:
         QString thingName;
     };
     QHash<PairingTransactionId, PairingContext> m_pendingPairings;
+    QHash<ThingId, ThingSetupInfo*> m_pendingSetups;
 
     QHash<IOConnectionId, IOConnection> m_ioConnections;
 

--- a/plugins/mock/integrationpluginmock.h
+++ b/plugins/mock/integrationpluginmock.h
@@ -51,8 +51,8 @@ public:
     void discoverThings(ThingDiscoveryInfo *info) override;
 
     void setupThing(ThingSetupInfo *info) override;
-    void postSetupThing(Thing *device) override;
-    void thingRemoved(Thing *device) override;
+    void postSetupThing(Thing *thing) override;
+    void thingRemoved(Thing *thing) override;
 
     void startMonitoringAutoThings() override;
 

--- a/tests/auto/devices/testdevices.cpp
+++ b/tests/auto/devices/testdevices.cpp
@@ -160,7 +160,7 @@ void TestDevices::initTestCase()
     NymeaTestBase::initTestCase();
     QLoggingCategory::setFilterRules("*.debug=false\n"
                                      "Tests.debug=true\n"
-                                     "MockDevice.debug=true\n"
+                                     "Mock.debug=true\n"
                                      );
 
     // Adding an async mock device to be used in tests below
@@ -619,6 +619,7 @@ void TestDevices::storedDevices()
 
     params.clear();
     params.insert("deviceId", addedDeviceId);
+    qCDebug(dcTests()) << "Cleaning up mock device again";
     response = injectAndWait("Devices.RemoveConfiguredDevice", params);
     verifyDeviceError(response);
 }


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
