### PR TITLE
Disable deprecation errors to allow building with gcc 10/Qt 5.15

### DIFF
--- a/libnymea/integrations/plugin.pri
+++ b/libnymea/integrations/plugin.pri
@@ -31,7 +31,7 @@ CONFIG += plugin link_pkgconfig
 
 PKGCONFIG += nymea
 
-QMAKE_CXXFLAGS *= -Werror -std=c++11 -g
+QMAKE_CXXFLAGS *= -Werror -std=c++11 -g -Wno-deprecated-declarations
 QMAKE_LFLAGS *= -std=c++11 -z defs
 
 JSONFILE=$${_PRO_FILE_PWD_}/integrationplugin"$$TARGET".json

--- a/nymea.pri
+++ b/nymea.pri
@@ -3,7 +3,7 @@ COPYRIGHT_YEAR_TO=2021
 
 DEFINES += COPYRIGHT_YEAR_STRING=\\\"$${COPYRIGHT_YEAR_FROM}-$${COPYRIGHT_YEAR_TO}\\\"
 
-QMAKE_CXXFLAGS *= -Werror -std=c++11 -g
+QMAKE_CXXFLAGS *= -Werror -std=c++11 -g -Wno-deprecated-declarations
 QMAKE_LFLAGS *= -std=c++11
 
 top_srcdir=$$PWD


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
