### PR TITLE
Use pkgconfig to find zigbee also for tests

### DIFF
--- a/server/server.pro
+++ b/server/server.pro
@@ -14,6 +14,9 @@ LIBS += -L$$top_builddir/libnymea/ -lnymea \
         -L$$top_builddir/libnymea-core -lnymea-core \
         -lnymea-remoteproxyclient
 
+CONFIG += link_pkgconfig
+PKGCONFIG += nymea-zigbee
+
 # Server files
 include(qtservice/qtservice.pri)
 

--- a/tests/auto/autotests.pri
+++ b/tests/auto/autotests.pri
@@ -14,6 +14,8 @@ packagesExist(Qt5SerialBus) {
     message("Qt5SerialBus package not found. Building without QtSerialBus support.")
 }
 
+PKGCONFIG += nymea-zigbee
+
 INCLUDEPATH += $$top_srcdir/libnymea \
                $$top_srcdir/libnymea-core \
                $$top_srcdir/tests/testlib/ \

--- a/tests/testlib/testlib.pro
+++ b/tests/testlib/testlib.pro
@@ -5,6 +5,9 @@ include(../../nymea.pri)
 
 QT += testlib dbus network sql websockets
 
+CONFIG += link_pkgconfig
+PKGCONFIG += nymea-zigbee
+
 # Qt serial bus module is officially available since Qt 5.8
 # but not all platforms host the qt serialbus package.
 # Let's check if the package exists, not the qt version


### PR DESCRIPTION
Otherwise it would fail to build when libnymea-zigbee is not installed system-wide.