### PR TITLE
Make the state cache configurable and async by default

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.h
+++ b/libnymea-core/integrations/thingmanagerimplementation.h
@@ -68,7 +68,7 @@ class ThingManagerImplementation: public ThingManager
     friend class IntegrationPlugin;
 
 public:
-    explicit ThingManagerImplementation(HardwareManager *hardwareManager, const QLocale &locale, QObject *parent = nullptr);
+    explicit ThingManagerImplementation(HardwareManager *hardwareManager, QObject *parent = nullptr);
     ~ThingManagerImplementation() override;
 
     static QStringList pluginSearchDirs();
@@ -175,7 +175,6 @@ private:
 private:
     HardwareManager *m_hardwareManager;
 
-    QLocale m_locale;
     Translator *m_translator = nullptr;
     QHash<VendorId, Vendor> m_supportedVendors;
     QHash<QString, Interface> m_supportedInterfaces;
@@ -200,6 +199,8 @@ private:
     QHash<IOConnectionId, IOConnection> m_ioConnections;
 
     ApiKeysProvidersLoader *m_apiKeysProvidersLoader = nullptr;
+
+    bool m_syncStateCache = false;
 };
 
 #endif // THINGMANAGERIMPLEMENTATION_H

--- a/libnymea-core/nymeaconfiguration.cpp
+++ b/libnymea-core/nymeaconfiguration.cpp
@@ -70,6 +70,7 @@ NymeaConfiguration::NymeaConfiguration(QObject *parent) :
     setBluetoothServerEnabled(bluetoothServerEnabled());
     setSslCertificate(sslCertificate(), sslCertificateKey());
     setDebugServerEnabled(debugServerEnabled());
+    setSyncStateCache(syncStateCache());
 
     NymeaSettings settings(NymeaSettings::SettingsRoleGlobal);
 
@@ -575,6 +576,21 @@ void NymeaConfiguration::setSslCertificate(const QString &sslCertificate, const 
     settings.beginGroup("SSL");
     settings.setValue("certificate", sslCertificate);
     settings.setValue("certificate-key", sslCertificateKey);
+    settings.endGroup();
+}
+
+bool NymeaConfiguration::syncStateCache() const
+{
+    NymeaSettings settings(NymeaSettings::SettingsRoleGlobal);
+    settings.beginGroup("nymead");
+    return settings.value("syncStateCache", false).toBool();
+}
+
+void NymeaConfiguration::setSyncStateCache(bool syncStateCache)
+{
+    NymeaSettings settings(NymeaSettings::SettingsRoleGlobal);
+    settings.beginGroup("nymead");
+    settings.setValue("syncStateCache", syncStateCache);
     settings.endGroup();
 }
 

--- a/libnymea-core/nymeaconfiguration.h
+++ b/libnymea-core/nymeaconfiguration.h
@@ -128,6 +128,9 @@ public:
     QString sslCertificateKey() const;
     void setSslCertificate(const QString &sslCertificate, const QString &sslCertificateKey);
 
+    bool syncStateCache() const;
+    void setSyncStateCache(bool syncStateCache);
+
     // Debug server
     bool debugServerEnabled() const;
     void setDebugServerEnabled(bool enabled);

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -121,7 +121,7 @@ void NymeaCore::init(const QStringList &additionalInterfaces) {
     m_hardwareManager = new HardwareManagerImplementation(m_platform, m_serverManager->mqttBroker(), m_zigbeeManager, m_modbusRtuManager, this);
 
     qCDebug(dcCore) << "Creating Thing Manager (locale:" << m_configuration->locale() << ")";
-    m_thingManager = new ThingManagerImplementation(m_hardwareManager, m_configuration->locale(), this);
+    m_thingManager = new ThingManagerImplementation(m_hardwareManager, this);
 
     qCDebug(dcCore) << "Creating Rule Engine";
     m_ruleEngine = new RuleEngine(this);


### PR DESCRIPTION
nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
