### PR TITLE
Remove cloud push notifications

### DIFF
--- a/libnymea-core/cloud/awsconnector.h
+++ b/libnymea-core/cloud/awsconnector.h
@@ -45,13 +45,6 @@ public:
     explicit AWSConnector(QObject *parent = nullptr);
     ~AWSConnector();
 
-    class PushNotificationsEndpoint {
-    public:
-        QString userId;
-        QString endpointId;
-        QString displayName;
-    };
-
     void connect2AWS(const QString &endpoint, const QString &clientId, const QString &clientName, const QString &caFile, const QString &clientCertFile, const QString &clientPrivKeyFile);
     void disconnectAWS();
     bool isConnected() const;
@@ -59,16 +52,10 @@ public:
     void setDeviceName(const QString &deviceName);
     void pairDevice(const QString &idToken, const QString &userId);
 
-public slots:
-    int sendPushNotification(const QString &userId, const QString &endpointId, const QString &title, const QString &text);
-
 signals:
     void connected();
     void disconnected();
     void devicePaired(const QString &cognritoUserId, int errorCode, const QString &message);
-    void pushNotificationEndpointsUpdated(const QList<AWSConnector::PushNotificationsEndpoint> pushNotificationEndpoints);
-    void pushNotificationEndpointAdded(const AWSConnector::PushNotificationsEndpoint &pushNotificationEndpoint);
-    void pushNotificationSent(int id, int status);
 
     void proxyConnectionRequestReceived(const QString &token, const QString &nonce, const QString &serverUrl);
 
@@ -126,6 +113,5 @@ private:
     QPair<QVariantMap, QDateTime> m_cachedTURNCredentials;
 
 };
-Q_DECLARE_METATYPE(AWSConnector::PushNotificationsEndpoint)
 
 #endif // AWSCONNECTOR_H

--- a/libnymea-core/cloud/cloudnotifications.h
+++ b/libnymea-core/cloud/cloudnotifications.h
@@ -32,32 +32,20 @@
 #define CLOUDNOTIFICATIONS_H
 
 #include "integrations/integrationplugin.h"
-#include "awsconnector.h"
 
 class CloudNotifications : public IntegrationPlugin
 {
     Q_OBJECT
 
-//    Q_PLUGIN_METADATA(IID "io.nymea.IntegrationPlugin" FILE "deviceplugincloudnotifications.json")
     Q_INTERFACES(IntegrationPlugin)
 
 public:
-    CloudNotifications(AWSConnector *awsConnector, QObject* parent = nullptr);
+    CloudNotifications(QObject* parent = nullptr);
 
     PluginMetadata metaData() const;
 
     void setupThing(ThingSetupInfo *info) override;
-    void startMonitoringAutoThings() override;
-    void executeAction(ThingActionInfo *info) override;
-
-private slots:
-    void pushNotificationEndpointsUpdated(const QList<AWSConnector::PushNotificationsEndpoint> &endpoints);
-    void pushNotificationEndpointAdded(const AWSConnector::PushNotificationsEndpoint &endpoint);
-    void pushNotificationSent(int id, int status);
-
-private:
-    AWSConnector *m_awsConnector = nullptr;
-    QHash<int, ThingActionInfo*> m_pendingPushNotifications;
+    void postSetupThing(Thing *thing) override;
 };
 
 #endif // CLOUDNOTIFICATIONS_H

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -151,6 +151,9 @@ void NymeaCore::init(const QStringList &additionalInterfaces) {
     m_experienceManager = new ExperienceManager(m_thingManager, m_serverManager->jsonServer(), this);
 
 
+    // To be removed with 0.31 or later.
+    // Most of the cloud push notifications code has been removed with 0.30, this is just kept for a release or two
+    // to auto-remove all the cloud based push notification things users might have in their systems
     CloudNotifications *cloudNotifications = m_cloudManager->createNotificationsPlugin();
     m_thingManager->registerStaticPlugin(cloudNotifications);
 


### PR DESCRIPTION
Note: This doesn't remove 100% of the related code yet, just keeps
the minimum required to emit autoThingDisappeared() for all the
things and clean up users setups.

The rest of the CloudNotifications class code shall be removed
with 0.31 (or soonish after that).

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
