### PR TITLE
Fix a double-free when shutting down the python engine.

### DIFF
--- a/libnymea-core/integrations/pythonintegrationplugin.h
+++ b/libnymea-core/integrations/pythonintegrationplugin.h
@@ -81,7 +81,6 @@ private:
     PyObject *m_nymeaModule = nullptr;
     // The imported plugin module (the plugin.py)
     PyObject *m_pluginModule = nullptr;
-    PyObject *m_logger = nullptr;
     PyObject *m_stdOutHandler = nullptr;
     PyObject *m_stdErrHandler = nullptr;
 

--- a/tests/auto/pythonplugins/testpythonplugins.cpp
+++ b/tests/auto/pythonplugins/testpythonplugins.cpp
@@ -51,17 +51,22 @@ private slots:
 
     void initTestCase();
 
+    void testRestartServer();
+
     void setupAndRemoveThing();
     void testDiscoverPairAndRemoveThing();
 
 
 };
 
+void TestPythonPlugins::testRestartServer()
+{
+    NymeaTestBase::restartServer();
+}
 
 void TestPythonPlugins::initTestCase()
 {
-    NymeaTestBase::initTestCase();
-    QLoggingCategory::setFilterRules("*.debug=false\n"
+    NymeaTestBase::initTestCase("*.debug=false\n*.info=false\n*.warning=false\n"
                                      "Tests.debug=true\n"
                                      "PyMock.debug=true\n"
                                      "PythonIntegrations.debug=true\n"

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -53,7 +53,7 @@ NymeaTestBase::NymeaTestBase(QObject *parent) :
     QCoreApplication::instance()->setOrganizationName("nymea-test");
 }
 
-void NymeaTestBase::initTestCase()
+void NymeaTestBase::initTestCase(const QString &loggingRules)
 {
     qCDebug(dcTests) << "NymeaTestBase starting.";
 
@@ -71,7 +71,11 @@ void NymeaTestBase::initTestCase()
     NymeaSettings nymeadSettings(NymeaSettings::SettingsRoleGlobal);
     nymeadSettings.clear();
 
-    QLoggingCategory::setFilterRules("*.debug=false\nApplication.debug=true\nTests.debug=true\nMock.debug=true");
+    if (loggingRules.isEmpty()) {
+        QLoggingCategory::setFilterRules("*.debug=false\nApplication.debug=true\nTests.debug=true\nMock.debug=true");
+    } else {
+        QLoggingCategory::setFilterRules(loggingRules);
+    }
 
     // Start the server
     qCDebug(dcTests()) << "Setting up nymea core instance";

--- a/tests/testlib/nymeatestbase.h
+++ b/tests/testlib/nymeatestbase.h
@@ -50,7 +50,7 @@ public:
     explicit NymeaTestBase(QObject *parent = nullptr);
 
 protected slots:
-    void initTestCase();
+    void initTestCase(const QString &loggingRules = QString());
     void cleanupTestCase();
     void cleanup();
 


### PR DESCRIPTION
Python_AddObject() will steal the reference and delete it. Since we
deleted m_logger ourselves too, a double free would corrupt memory
on nymea shutdown.
This would cause tests to crash when restarting the core within
a single process by restartServer()

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
