### PR TITLE
Fix a crash when removing a currently connected transport

### DIFF
--- a/libnymea-core/servers/tcpserver.cpp
+++ b/libnymea-core/servers/tcpserver.cpp
@@ -201,6 +201,10 @@ bool TcpServer::stopServer()
     if (!m_server)
         return true;
 
+    foreach (QTcpSocket *client, m_clientList) {
+        client->abort();
+    }
+
     m_server->close();
     m_server->deleteLater();
     m_server = nullptr;

--- a/libnymea-core/servers/websocketserver.cpp
+++ b/libnymea-core/servers/websocketserver.cpp
@@ -239,7 +239,7 @@ bool WebSocketServer::stopServer()
 
     if (m_server) {
         m_server->close();
-        delete m_server;
+        m_server->deleteLater();
         m_server = nullptr;
     }
     return true;


### PR DESCRIPTION
Both, the TCP transport as well as the WebSocket transport were
crashing on this, but with different bugs.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
