### PR TITLE
Split thing cache into individual files

### DIFF
--- a/libnymea-core/debugreportgenerator.cpp
+++ b/libnymea-core/debugreportgenerator.cpp
@@ -207,7 +207,6 @@ void DebugReportGenerator::saveConfigs()
     // Start copy files setting files
     copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRoleGlobal).fileName(), "config");
     copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRoleThings).fileName(), "config");
-    copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRoleThingStates).fileName(), "config");
     copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRoleRules).fileName(), "config");
     copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRolePlugins).fileName(), "config");
     copyFileToReportDirectory(NymeaSettings(NymeaSettings::SettingsRoleTags).fileName(), "config");

--- a/libnymea-core/debugserverhandler.cpp
+++ b/libnymea-core/debugserverhandler.cpp
@@ -227,34 +227,6 @@ HttpReply *DebugServerHandler::processDebugRequest(const QString &requestPath, c
             return reply;
         }
 
-        if (requestPath.startsWith("/debug/settings/thingstates")) {
-            QString settingsFileName = NymeaSettings(NymeaSettings::SettingsRoleThingStates).fileName();
-            qCDebug(dcDebugServer()) << "Loading" << settingsFileName;
-            QFile settingsFile(settingsFileName);
-            if (!settingsFile.exists()) {
-                qCWarning(dcDebugServer()) << "Could not read file for debug download" << settingsFileName << "file does not exist.";
-                HttpReply *reply = HttpReply::createErrorReply(HttpReply::NotFound);
-                reply->setHeader(HttpReply::ContentTypeHeader, "text/html");
-                reply->setPayload(createErrorXmlDocument(HttpReply::NotFound, tr("Could not find file \"%1\".").arg(settingsFileName)));
-                return reply;
-            }
-
-            if (!settingsFile.open(QFile::ReadOnly)) {
-                qCWarning(dcDebugServer()) << "Could not read file for debug download" << settingsFileName;
-                HttpReply *reply = HttpReply::createErrorReply(HttpReply::Forbidden);
-                reply->setHeader(HttpReply::ContentTypeHeader, "text/html");
-                reply->setPayload(createErrorXmlDocument(HttpReply::NotFound, tr("Could not open file \"%1\".").arg(settingsFileName)));
-                return reply;
-            }
-
-            QByteArray settingsFileData = settingsFile.readAll();
-            settingsFile.close();
-
-            HttpReply *reply = HttpReply::createSuccessReply();
-            reply->setHeader(HttpReply::ContentTypeHeader, "text/plain");
-            reply->setPayload(settingsFileData);
-            return reply;
-        }
 
         if (requestPath.startsWith("/debug/settings/plugins")) {
             QString settingsFileName = NymeaSettings(NymeaSettings::SettingsRolePlugins).fileName();
@@ -1383,56 +1355,6 @@ QByteArray DebugServerHandler::createDebugXmlDocument()
         writer.writeAttribute("disabled", "true");
     }
     writer.writeAttribute("onClick", "showFile('/debug/settings/things')");
-    writer.writeCharacters(tr("Show"));
-    writer.writeEndElement(); // button
-    writer.writeEndElement(); // form
-    writer.writeEndElement(); // div show-button-column
-
-    writer.writeEndElement(); // div download-row
-
-
-    // Download row thing states
-    writer.writeStartElement("div");
-    writer.writeAttribute("class", "download-row");
-
-    writer.writeStartElement("div");
-    writer.writeAttribute("class", "download-name-column");
-    //: The thing states settings download description of the debug interface
-    writer.writeTextElement("p", tr("Thing states settings"));
-    writer.writeEndElement(); // div download-name-column
-
-    writer.writeStartElement("div");
-    writer.writeAttribute("class", "download-path-column");
-    writer.writeTextElement("p", NymeaSettings(NymeaSettings::SettingsRoleThingStates).fileName());
-    writer.writeEndElement(); // div download-path-column
-
-    writer.writeStartElement("div");
-    writer.writeAttribute("class", "download-button-column");
-    writer.writeStartElement("form");
-    writer.writeAttribute("class", "download-button");
-    writer.writeStartElement("button");
-    writer.writeAttribute("class", "button");
-    writer.writeAttribute("type", "button");
-    if (!QFile::exists(NymeaSettings(NymeaSettings::SettingsRoleThingStates).fileName())) {
-        writer.writeAttribute("disabled", "true");
-    }
-    writer.writeAttribute("onClick", "downloadFile('/debug/settings/thingstates', 'thingstates.conf')");
-    writer.writeCharacters(tr("Download"));
-    writer.writeEndElement(); // button
-    writer.writeEndElement(); // form
-    writer.writeEndElement(); // div download-button-column
-
-    writer.writeStartElement("div");
-    writer.writeAttribute("class", "show-button-column");
-    writer.writeStartElement("form");
-    writer.writeAttribute("class", "show-button");
-    writer.writeStartElement("button");
-    writer.writeAttribute("class", "button");
-    writer.writeAttribute("type", "button");
-    if (!QFile::exists(NymeaSettings(NymeaSettings::SettingsRoleThingStates).fileName())) {
-        writer.writeAttribute("disabled", "true");
-    }
-    writer.writeAttribute("onClick", "showFile('/debug/settings/thingstates')");
     writer.writeCharacters(tr("Show"));
     writer.writeEndElement(); // button
     writer.writeEndElement(); // form

--- a/libnymea-core/integrations/thingmanagerimplementation.h
+++ b/libnymea-core/integrations/thingmanagerimplementation.h
@@ -162,6 +162,7 @@ private:
     void trySetupThing(Thing *thing);
     void registerThing(Thing *thing);
     void postSetupThing(Thing *thing);
+    QString statesCacheFile(const ThingId &thingId);
     void storeThingStates(Thing *thing);
     void storeThingState(Thing *thing, const StateTypeId &stateTypeId);
     void loadThingStates(Thing *thing);

--- a/libnymea/nymeasettings.cpp
+++ b/libnymea/nymeasettings.cpp
@@ -114,9 +114,6 @@ NymeaSettings::NymeaSettings(const SettingsRole &role, QObject *parent):
     case SettingsRoleGlobal:
         fileName = "nymead.conf";
         break;
-    case SettingsRoleThingStates:
-        fileName = "thingstates.conf";
-        break;
     case SettingsRoleTags:
         fileName = "tags.conf";
         break;
@@ -203,6 +200,22 @@ QString NymeaSettings::storagePath()
         path = "/var/lib/" + organisationName;
     } else {
         path = QDir::homePath() + "/.local/share/" + organisationName;
+    }
+    return path;
+}
+
+QString NymeaSettings::cachePath()
+{
+    QString path;
+    QString organisationName = QCoreApplication::instance()->organizationName();
+    if (!qEnvironmentVariableIsEmpty("SNAP")) {
+        path = QString(qgetenv("SNAP_DATA"));
+    } else if (organisationName == "nymea-test") {
+        path = "/tmp/" + organisationName;
+    } else if (NymeaSettings::isRoot()) {
+        path = "/var/cache/" + organisationName;
+    } else {
+        path = QDir::homePath() + "/.cache/" + organisationName;
     }
     return path;
 }

--- a/libnymea/nymeasettings.h
+++ b/libnymea/nymeasettings.h
@@ -48,7 +48,6 @@ public:
         SettingsRoleRules,
         SettingsRolePlugins,
         SettingsRoleGlobal,
-        SettingsRoleThingStates,
         SettingsRoleTags,
         SettingsRoleMqttPolicies,
         SettingsRoleIOConnections,
@@ -66,6 +65,7 @@ public:
     static QString settingsPath();
     static QString translationsPath();
     static QString storagePath();
+    static QString cachePath();
 
     // forwarded QSettings methods
     QStringList	allKeys() const;

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -64,8 +64,8 @@ void NymeaTestBase::initTestCase(const QString &loggingRules)
     thingSettings.clear();
     NymeaSettings pluginSettings(NymeaSettings::SettingsRolePlugins);
     pluginSettings.clear();
-    NymeaSettings statesSettings(NymeaSettings::SettingsRoleThingStates);
-    statesSettings.clear();
+    QDir dir(NymeaSettings::cachePath() + "/thingstates/");
+    dir.removeRecursively();
 
     // Reset to default settings
     NymeaSettings nymeadSettings(NymeaSettings::SettingsRoleGlobal);


### PR DESCRIPTION
Splits the state cache up into individual files which makes it a lot easier on the resources as parsing that single huge file becomes intensive on large setups.

Also moves the files from /etc/nymea/ to /var/cache/nymea/ which seems a much more appropriate place for a cache.
