### PR TITLE
Add discoveryType thing class property

### DIFF
--- a/libnymea-core/jsonrpc/integrationshandler.cpp
+++ b/libnymea-core/jsonrpc/integrationshandler.cpp
@@ -58,6 +58,7 @@ IntegrationsHandler::IntegrationsHandler(ThingManager *thingManager, QObject *pa
     registerEnum<Thing::ThingSetupStatus>();
     registerEnum<ThingClass::SetupMethod>();
     registerFlag<ThingClass::CreateMethod, ThingClass::CreateMethods>();
+    registerEnum<ThingClass::DiscoveryType>();
     registerEnum<Types::Unit>();
     registerEnum<Types::InputType>();
     registerEnum<Types::IOType>();

--- a/libnymea/integrations/pluginmetadata.cpp
+++ b/libnymea/integrations/pluginmetadata.cpp
@@ -203,7 +203,8 @@ void PluginMetadata::parse(const QJsonObject &jsonObject)
             /*! Returns a list of all valid JSON properties a ThingClass JSON definition can have. */
             QStringList thingClassProperties = QStringList() << "id" << "name" << "displayName" << "createMethods" << "setupMethod"
                                      << "interfaces" << "providedInterfaces" << "browsable" << "discoveryParamTypes"
-                                     << "paramTypes" << "settingsTypes" << "stateTypes" << "actionTypes" << "eventTypes" << "browserItemActionTypes";
+                                     << "paramTypes" << "settingsTypes" << "stateTypes" << "actionTypes" << "eventTypes" << "browserItemActionTypes"
+                                     << "discoveryType";
             QStringList mandatoryThingClassProperties = QStringList() << "id" << "name" << "displayName";
 
             QPair<QStringList, QStringList> verificationResult = verifyFields(thingClassProperties, mandatoryThingClassProperties, thingClassObject);
@@ -259,6 +260,20 @@ void PluginMetadata::parse(const QJsonObject &jsonObject)
                 }
             }
             thingClass.setCreateMethods(createMethods);
+
+            if (thingClassObject.contains("discoveryType")) {
+                QString discoveryTypeString = thingClassObject.value("discoveryType").toString();
+                if (discoveryTypeString == "precise") {
+                    thingClass.setDiscoveryType(ThingClass::DiscoveryTypePrecise);
+                } else if (discoveryTypeString == "weak") {
+                    thingClass.setDiscoveryType(ThingClass::DiscoveryTypeWeak);
+                } else {
+                    m_validationErrors.append("Unknown discoveryType \"" + discoveryTypeString + "\" in thingClass \"" + thingClass.name() +  "\".");
+                    hasError = true;
+                }
+            } else {
+                thingClass.setDiscoveryType(ThingClass::DiscoveryTypePrecise);
+            }
 
             // Read params
             QPair<bool, QList<ParamType> > paramTypesVerification = parseParamTypes(thingClassObject.value("paramTypes").toArray());

--- a/libnymea/types/thingclass.cpp
+++ b/libnymea/types/thingclass.cpp
@@ -79,9 +79,7 @@
 ThingClass::ThingClass(const PluginId &pluginId, const VendorId &vendorId, const ThingClassId &id):
     m_id(id),
     m_vendorId(vendorId),
-    m_pluginId(pluginId),
-    m_createMethods(CreateMethodUser),
-    m_setupMethod(SetupMethodJustAdd)
+    m_pluginId(pluginId)
 {
 
 }
@@ -340,6 +338,16 @@ ThingClass::SetupMethod ThingClass::setupMethod() const
 void ThingClass::setSetupMethod(ThingClass::SetupMethod setupMethod)
 {
     m_setupMethod = setupMethod;
+}
+
+ThingClass::DiscoveryType ThingClass::discoveryType() const
+{
+    return m_discoveryType;
+}
+
+void ThingClass::setDiscoveryType(DiscoveryType discoveryType)
+{
+    m_discoveryType = discoveryType;
 }
 
 /*! Returns the \l{Interfaces for DeviceClasses}{interfaces} of this \l{DeviceClass}.*/

--- a/libnymea/types/thingclass.h
+++ b/libnymea/types/thingclass.h
@@ -55,6 +55,7 @@ class LIBNYMEA_EXPORT ThingClass
     Q_PROPERTY(bool browsable READ browsable)
     Q_PROPERTY(SetupMethod setupMethod READ setupMethod)
     Q_PROPERTY(CreateMethods createMethods READ createMethods)
+    Q_PROPERTY(DiscoveryType discoveryType READ discoveryType)
     Q_PROPERTY(StateTypes stateTypes READ stateTypes)
     Q_PROPERTY(EventTypes eventTypes READ eventTypes)
     Q_PROPERTY(ActionTypes actionTypes READ actionTypes)
@@ -82,6 +83,12 @@ public:
         SetupMethodOAuth
     };
     Q_ENUM(SetupMethod)
+
+    enum DiscoveryType {
+        DiscoveryTypePrecise,
+        DiscoveryTypeWeak
+    };
+    Q_ENUM(DiscoveryType)
 
     ThingClass(const PluginId &pluginId = PluginId(), const VendorId &vendorId = VendorId(), const ThingClassId &id = ThingClassId());
 
@@ -134,6 +141,9 @@ public:
     SetupMethod setupMethod() const;
     void setSetupMethod(SetupMethod setupMethod);
 
+    DiscoveryType discoveryType() const;
+    void setDiscoveryType(DiscoveryType discoveryType);
+
     QStringList interfaces() const;
     void setInterfaces(const QStringList &interfaces);
 
@@ -156,8 +166,9 @@ private:
     ParamTypes m_paramTypes;
     ParamTypes m_settingsTypes;
     ParamTypes m_discoveryParamTypes;
-    CreateMethods m_createMethods;
-    SetupMethod m_setupMethod;
+    CreateMethods m_createMethods = CreateMethodUser;
+    SetupMethod m_setupMethod = SetupMethodJustAdd;
+    DiscoveryType m_discoveryType = DiscoveryTypePrecise;
     QStringList m_interfaces;
     QStringList m_providedInterfaces;
 };

--- a/tests/auto/api.json
+++ b/tests/auto/api.json
@@ -47,6 +47,10 @@
             "CreateMethodAuto",
             "CreateMethodDiscovery"
         ],
+        "DiscoveryType": [
+            "DiscoveryTypePrecise",
+            "DiscoveryTypeWeak"
+        ],
         "IOType": [
             "IOTypeNone",
             "IOTypeDigitalInput",
@@ -2620,6 +2624,7 @@
             "r:browserItemActionTypes": "$ref:ActionTypes",
             "r:createMethods": "$ref:CreateMethods",
             "r:discoveryParamTypes": "$ref:ParamTypes",
+            "r:discoveryType": "$ref:DiscoveryType",
             "r:displayName": "String",
             "r:eventTypes": "$ref:EventTypes",
             "r:id": "Uuid",


### PR DESCRIPTION
Some plugins may support network discovery, but may not be able to clearly
identify a device and return a list of discovery results that may
be the device, but also may not. As this breaks some app flows they
will be marked as "weak" discovery and can be excluded from said setup
wizards.

NOTE: This commit does not bump the API version even though it should
to avoid merge conflicts with other branches that do bump the version.

