### PR TITLE
Add a timeout to ModbusRtuReplies

### DIFF
--- a/libnymea-core/hardware/modbus/modbusrtumasterimpl.cpp
+++ b/libnymea-core/hardware/modbus/modbusrtumasterimpl.cpp
@@ -238,9 +238,10 @@ ModbusRtuReply *ModbusRtuMasterImpl::readCoil(int slaveAddress, int registerAddr
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::Coils, registerAddress, size);
     QModbusReply *modbusReply = m_modbus->sendReadRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -257,15 +258,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::readCoil(int slaveAddress, int registerAddr
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Read coil request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 
@@ -291,9 +283,10 @@ ModbusRtuReply *ModbusRtuMasterImpl::readDiscreteInput(int slaveAddress, int reg
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::DiscreteInputs, registerAddress, size);
     QModbusReply *modbusReply = m_modbus->sendReadRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -310,15 +303,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::readDiscreteInput(int slaveAddress, int reg
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Read descrete inputs request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 
@@ -344,9 +328,10 @@ ModbusRtuReply *ModbusRtuMasterImpl::readInputRegister(int slaveAddress, int reg
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::InputRegisters, registerAddress, size);
     QModbusReply *modbusReply = m_modbus->sendReadRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -363,15 +348,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::readInputRegister(int slaveAddress, int reg
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Read input registers request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 
@@ -397,9 +373,10 @@ ModbusRtuReply *ModbusRtuMasterImpl::readHoldingRegister(int slaveAddress, int r
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::HoldingRegisters, registerAddress, size);
     QModbusReply *modbusReply = m_modbus->sendReadRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -416,15 +393,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::readHoldingRegister(int slaveAddress, int r
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Read holding registers request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 
@@ -449,12 +417,12 @@ ModbusRtuReply *ModbusRtuMasterImpl::writeCoils(int slaveAddress, int registerAd
     // Create the actual modbus lib reply
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::Coils, registerAddress, values.length());
     request.setValues(values);
-
     QModbusReply *modbusReply = m_modbus->sendWriteRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -471,15 +439,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::writeCoils(int slaveAddress, int registerAd
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Write coil request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 
@@ -505,12 +464,12 @@ ModbusRtuReply *ModbusRtuMasterImpl::writeHoldingRegisters(int slaveAddress, int
     // Create the actual modbus lib reply
     QModbusDataUnit request = QModbusDataUnit(QModbusDataUnit::RegisterType::HoldingRegisters, registerAddress, values.length());
     request.setValues(values);
-
     QModbusReply *modbusReply = m_modbus->sendWriteRequest(request, slaveAddress);
 
-    connect(modbusReply, &QModbusReply::finished, modbusReply, [=](){
-        modbusReply->deleteLater();
+    // Cleaning up modbusReply when our reply finishes, regardless if that happened because modbusReply finished or reply timeouted
+    connect(reply, &ModbusRtuReply::finished, modbusReply, &QModbusReply::deleteLater);
 
+    connect(modbusReply, &QModbusReply::finished, reply, [=](){
         // Fill common reply data
         reply->setFinished(true);
         reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
@@ -527,15 +486,6 @@ ModbusRtuReply *ModbusRtuMasterImpl::writeHoldingRegisters(int slaveAddress, int
         // Parse the data unit and set reply result
         const QModbusDataUnit unit = modbusReply->result();
         reply->setResult(unit.values());
-        emit reply->finished();
-    });
-
-    connect(modbusReply, &QModbusReply::errorOccurred, modbusReply, [=](QModbusDevice::Error error){
-        qCWarning(dcModbusRtu()) << "Write holding register request finished with error" << error << modbusReply->errorString();
-        reply->setFinished(true);
-        reply->setError(static_cast<ModbusRtuReply::Error>(modbusReply->error()));
-        reply->setErrorString(modbusReply->errorString());
-        emit reply->errorOccurred(reply->error());
         emit reply->finished();
     });
 

--- a/libnymea-core/hardware/modbus/modbusrtureplyimpl.cpp
+++ b/libnymea-core/hardware/modbus/modbusrtureplyimpl.cpp
@@ -37,7 +37,13 @@ ModbusRtuReplyImpl::ModbusRtuReplyImpl(int slaveAddress, int registerAddress, QO
     m_slaveAddress(slaveAddress),
     m_registerAddress(registerAddress)
 {
-
+    m_timeoutTimer.start(10000);
+    connect(&m_timeoutTimer, &QTimer::timeout, this, [=](){
+        if (!m_finished) {
+            m_error = TimeoutError;
+            emit errorOccurred(TimeoutError);
+        }
+    });
 }
 
 bool ModbusRtuReplyImpl::isFinished() const

--- a/libnymea-core/hardware/modbus/modbusrtureplyimpl.h
+++ b/libnymea-core/hardware/modbus/modbusrtureplyimpl.h
@@ -32,6 +32,7 @@
 #define MODBUSRTUREPLYIMPL_H
 
 #include <QObject>
+#include <QTimer>
 
 #include "hardware/modbus/modbusrtureply.h"
 
@@ -65,7 +66,7 @@ private:
     Error m_error = UnknownError;
     QString m_errorString;
     QVector<quint16> m_result;
-
+    QTimer m_timeoutTimer;
 };
 
 }


### PR DESCRIPTION
If unplugging the modbus adapter after a request is sent out but
before the reply arrives, Qt apparently doesn't ever finish
the replies.

