### PR TITLE
Add rpath to nymead binary

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -16,11 +16,11 @@ ifeq (,$(filter nodoc,$(DEB_BUILD_OPTIONS)))
 	MAKE_TARGETS += doc
 endif 
 
-QMAKE_ADDITIONAL_ARGS=
+QMAKE_ADDITIONAL_ARGS = CONFIG+=norpath
 ifneq (,$(filter coverage,$(DEB_BUILD_OPTIONS)))
-	QMAKE_ADDITIONAL_ARGS += CONFIG+=coverage CONFIG+=debug
+        QMAKE_ADDITIONAL_ARGS += CONFIG+=coverage CONFIG+=debug
 else
-	QMAKE_ADDITIONAL_ARGS += CONFIG+=release
+        QMAKE_ADDITIONAL_ARGS += CONFIG+=release
 endif
 
 DPKG_EXPORT_BUILDFLAGS = 1

--- a/server/server.pro
+++ b/server/server.pro
@@ -17,6 +17,12 @@ LIBS += -L$$top_builddir/libnymea/ -lnymea \
         -L$$top_builddir/libnymea-core -lnymea-core \
         -lnymea-remoteproxyclient
 
+# Add rpath for easy running from the build dir, unless explicitly disabled
+!norpath: {
+    message("Adding rpath to nymead binary")
+    LIBS += -Wl,-rpath ../libnymea/:../libnymea-core/
+}
+
 CONFIG += link_pkgconfig
 PKGCONFIG += nymea-zigbee
 


### PR DESCRIPTION
This allows to run it from the build directory without having to
specify LD_LIBRARY_PATH.

This is particularly useful when working with parts that require
special capabilities when ran as user, such as the NetworkDiscovery.
Given that setcap on a binary disables LD_LIBRARY_LATH loading for
security reasons, this the only way to allow working as non-root.

Building the dpkg package, the rpath will be stripped again.
Downside is a new build dependency to chrpath for stripping it.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update the documentation?

- [x] Did you update translations (cd builddir && make lupdate)?
