### PR TITLE
Fix filters generating wrong data types

### DIFF
--- a/libnymea/integrations/thing.cpp
+++ b/libnymea/integrations/thing.cpp
@@ -401,6 +401,7 @@ void Thing::setStateValue(const StateTypeId &stateTypeId, const QVariant &value)
             if (filter) {
                 filter->addValue(newValue);
                 newValue = filter->filteredValue();
+                newValue.convert(stateType.type());
             }
 
             QVariant oldValue = m_states.at(i).value();


### PR DESCRIPTION
When enabling a jitter filter on integer states (e.g. a signal
strength that repeatedly jumps up and down by 1), old code
may cause integer state to be populated with floating point values
as the filtering happens after the intial validation for the new
value being valid.

nymea:core pull request checklist:

Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

Did you update the documentation?

Did you update translations (cd builddir && make lupdate)?
