### PR TITLE
Fix webserver tests

### DIFF
--- a/libnymea-core/servers/webserver.cpp
+++ b/libnymea-core/servers/webserver.cpp
@@ -169,7 +169,7 @@ bool WebServer::verifyFile(QSslSocket *socket, const QString &fileName)
 
     // make sure the file is in the public directory
     if (!file.canonicalFilePath().startsWith(QDir(m_configuration.publicFolder).canonicalPath())) {
-        qCDebug(dcWebServer()) << "Requested file" << file.fileName() << "is outside the public folder.";
+        qCDebug(dcWebServer()) << "Requested file" << file.canonicalFilePath() << "is outside the public folder.";
         HttpReply *reply = HttpReply::createErrorReply(HttpReply::Forbidden);
         reply->setClientId(m_clientList.key(socket));
         sendHttpReply(reply);


### PR DESCRIPTION
canonicalFilePath() behavior seems to have changed at some point
and not existing files outside the public dir will return a 404
rather than a 403. Ideally the logic would be fixed to first
check for the file being outside the public directory, directly
returning a 403, then checking if the file exists, return a 404
if not, and lastly check for permissions on the file and return
a 403 again of denied. However, that would result in a bigger
change.

Also, the tests were failing all along if syslog exists but is
not readable (code is ok, just bad test) but none of our
autotesters seemed to have such a setup till now.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
