### PR TITLE
Print a better warning when setStateValue() is called with a wrong name

### DIFF
--- a/libnymea/integrations/thing.cpp
+++ b/libnymea/integrations/thing.cpp
@@ -423,6 +423,11 @@ void Thing::setStateValue(const StateTypeId &stateTypeId, const QVariant &value)
 void Thing::setStateValue(const QString &stateName, const QVariant &value)
 {
     StateTypeId stateTypeId = m_thingClass.stateTypes().findByName(stateName).id();
+    if (stateTypeId.isNull()) {
+        qCWarning(dcThing()) << "No such state" << stateName << "in" << m_name << "(" + thingClass().name() + ")";
+        return;
+    }
+
     setStateValue(stateTypeId, value);
 }
 


### PR DESCRIPTION
nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
