### PR TITLE
Some fixes in Coap

### DIFF
--- a/libnymea/coap/coap.cpp
+++ b/libnymea/coap/coap.cpp
@@ -801,16 +801,15 @@ void Coap::hostLookupFinished(const QHostInfo &hostInfo)
 void Coap::onReadyRead()
 {
     QHostAddress hostAddress;
-    QByteArray data;
     quint16 port;
 
     while (m_socket->hasPendingDatagrams()) {
-        data.resize(m_socket->pendingDatagramSize());
-        m_socket->readDatagram(data.data(), data.size(), &hostAddress, &port);
+        QByteArray datagram(m_socket->pendingDatagramSize(), 0);
+        m_socket->readDatagram(datagram.data(), datagram.size(), &hostAddress, &port);
+        qCDebug(dcCoap()) << "Datagram received from:" << hostAddress << ":" << datagram;
+        CoapPdu pdu(datagram);
+        processResponse(pdu, hostAddress, port);
     }
-
-    CoapPdu pdu(data);
-    processResponse(pdu, hostAddress, port);
 }
 
 void Coap::onReplyTimeout()

--- a/libnymea/coap/coappdu.h
+++ b/libnymea/coap/coappdu.h
@@ -68,6 +68,7 @@ public:
         Acknowledgement = 0x02,
         Reset           = 0x03
     };
+    Q_ENUM(MessageType)
 
     // Methods:       https://tools.ietf.org/html/rfc7252#section-5.8
     // Respond codes: https://tools.ietf.org/html/rfc7252#section-12.1.2
@@ -101,6 +102,7 @@ public:
         GatewayTimeout           = 0xa4,  // 5.04
         ProxyingNotSupported     = 0xa5   // 5.05
     };
+    Q_ENUM(StatusCode)
 
     // https://tools.ietf.org/html/rfc7252#section-12.3
     enum ContentType {
@@ -111,6 +113,7 @@ public:
         ApplicationExi   = 47,
         ApplicationJson  = 50
     };
+    Q_ENUM(ContentType)
 
     enum Error {
         NoError,
@@ -120,6 +123,7 @@ public:
         InvalidOptionLengthError,
         UnknownOptionError
     };
+    Q_ENUM(Error)
 
     CoapPdu(QObject *parent = 0);
     CoapPdu(const QByteArray &data, QObject *parent = 0);

--- a/libnymea/coap/coapreply.h
+++ b/libnymea/coap/coapreply.h
@@ -132,8 +132,8 @@ private:
     int m_messageId;
     QByteArray m_messageToken;
 
-    bool m_observation;
-    bool m_observationEnable;
+    bool m_observation = false;
+    bool m_observationEnable = false;
 
 signals:
     void timeout();


### PR DESCRIPTION
* Fixed an indexOutOfRange warning when creating coap requests 
  because the first addOption() call was calling 
  m_options.insert(1) on an empty list.

* Old code was appending multiple UDP datagrams to a single big Coap
  message, however, Coap is specified to only send s single datagram
  per message. The datagram length specifies the payload size.

* some boolean member variables weren't initialized which resulted in
  occational wrong flags.

* Parsing had issues with determining the option length in some occations
  and also would crash when receiving coap messages without any options
  or payload. To get rid of the complex and erraneous index calculations,
  the entire package parsing is now using a DataStream.

(This makes it work with Shelly devices)

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
