### PR TITLE
Add support for CoIoT

### DIFF
--- a/libnymea/coap/coap.h
+++ b/libnymea/coap/coap.h
@@ -65,11 +65,14 @@ public:
     CoapReply *put(const CoapRequest &request, const QByteArray &data = QByteArray());
     CoapReply *post(const CoapRequest &request, const QByteArray &data = QByteArray());
     CoapReply *deleteResource(const CoapRequest &request);
+    CoapReply *customRequest(CoapPdu::ReqRspCode requestCode, const CoapRequest &request, const QByteArray &data = QByteArray());
 
     // Notifications for observable resources
     CoapReply *enableResourceNotifications(const CoapRequest &request);
     CoapReply *disableNotifications(const CoapRequest &request);
 
+    bool joinMulticastGroup(const QHostAddress &address = QHostAddress("224.0.1.187"));
+    bool leaveMulticastGroup(const QHostAddress &address = QHostAddress("224.0.1.187"));
 
 private:
     QUdpSocket *m_socket;
@@ -105,6 +108,7 @@ private:
 signals:
     void replyFinished(CoapReply *reply);
     void notificationReceived(const CoapObserveResource &resource, const int &notificationNumber, const QByteArray &payload);
+    void multicastMessageReceived(const QHostAddress &source, const CoapPdu &pdu);
 
 private slots:
     void hostLookupFinished(const QHostInfo &hostInfo);

--- a/libnymea/coap/coappdu.h
+++ b/libnymea/coap/coappdu.h
@@ -72,7 +72,7 @@ public:
 
     // Methods:       https://tools.ietf.org/html/rfc7252#section-5.8
     // Respond codes: https://tools.ietf.org/html/rfc7252#section-12.1.2
-    enum StatusCode {
+    enum ReqRspCode {
         Empty                    = 0x00,  // Empty message (ping)
         Get                      = 0x01,  // Method GET
         Post                     = 0x02,  // Method POST
@@ -102,7 +102,7 @@ public:
         GatewayTimeout           = 0xa4,  // 5.04
         ProxyingNotSupported     = 0xa5   // 5.05
     };
-    Q_ENUM(StatusCode)
+    Q_ENUM(ReqRspCode)
 
     // https://tools.ietf.org/html/rfc7252#section-12.3
     enum ContentType {
@@ -128,24 +128,24 @@ public:
     CoapPdu(QObject *parent = 0);
     CoapPdu(const QByteArray &data, QObject *parent = 0);
 
-    static QString getStatusCodeString(const StatusCode &statusCode);
+    static QString getReqRspCodeString(CoapPdu::ReqRspCode reqRspCode);
 
     // header fields
     quint8 version() const;
-    void setVersion(const quint8 &version);
+    void setVersion(quint8 version);
 
     MessageType messageType() const;
-    void setMessageType(const MessageType &messageType);
+    void setMessageType(MessageType messageType);
 
-    StatusCode statusCode() const;
-    void setStatusCode(const StatusCode &statusCode);
+    ReqRspCode reqRspCode() const;
+    void setReqRspCode(ReqRspCode reqRspCode);
 
     quint16 messageId() const;
     void createMessageId();
-    void setMessageId(const quint16 &messageId);
+    void setMessageId(quint16 messageId);
 
     ContentType contentType() const;
-    void setContentType(const ContentType &contentType);
+    void setContentType(ContentType contentType);
 
     QByteArray token() const;
     void createToken();
@@ -156,11 +156,12 @@ public:
     void setPayload(const QByteArray &payload);
 
     QList<CoapOption> options() const;
-    void addOption(const CoapOption::Option &option, const QByteArray &data);
+    void addOption(CoapOption::Option option, const QByteArray &data);
 
     CoapPduBlock block() const;
 
-    bool hasOption(const CoapOption::Option &option) const;
+    bool hasOption(CoapOption::Option option) const;
+    CoapOption option(CoapOption::Option option) const;
 
     void clear();
     bool isValid() const;
@@ -170,7 +171,7 @@ public:
 private:
     quint8 m_version;
     MessageType m_messageType;
-    StatusCode m_statusCode;
+    ReqRspCode m_reqRspCode;
     quint16 m_messageId;
     ContentType m_contentType;
     QByteArray m_token;

--- a/libnymea/coap/coapreply.cpp
+++ b/libnymea/coap/coapreply.cpp
@@ -184,10 +184,10 @@ CoapPdu::MessageType CoapReply::messageType() const
     return m_messageType;
 }
 
-/*! Returns the \l{CoapPdu::StatusCode} of this \l{CoapReply}. */
-CoapPdu::StatusCode CoapReply::statusCode() const
+/*! Returns the \l{CoapPdu::ReqRspCode} of this \l{CoapReply}. */
+CoapPdu::ReqRspCode CoapReply::reqRspCode() const
 {
-    return m_statusCode;
+    return m_reqRspCode;
 }
 
 CoapReply::CoapReply(const CoapRequest &request, QObject *parent) :
@@ -198,7 +198,7 @@ CoapReply::CoapReply(const CoapRequest &request, QObject *parent) :
     m_retransmissions(1),
     m_contentType(CoapPdu::TextPlain),
     m_messageType(CoapPdu::Acknowledgement),
-    m_statusCode(CoapPdu::Empty),
+    m_reqRspCode(CoapPdu::Empty),
     m_lockedUp(false)
 {
     m_timer = new QTimer(this);
@@ -275,19 +275,19 @@ void CoapReply::resend()
     }
 }
 
-void CoapReply::setContentType(const CoapPdu::ContentType contentType)
+void CoapReply::setContentType(CoapPdu::ContentType contentType)
 {
     m_contentType = contentType;
 }
 
-void CoapReply::setMessageType(const CoapPdu::MessageType &messageType)
+void CoapReply::setMessageType(CoapPdu::MessageType messageType)
 {
     m_messageType = messageType;
 }
 
-void CoapReply::setStatusCode(const CoapPdu::StatusCode &statusCode)
+void CoapReply::setReqRspCode(CoapPdu::ReqRspCode reqRspCode)
 {
-    m_statusCode = statusCode;
+    m_reqRspCode = reqRspCode;
 }
 
 void CoapReply::setHostAddress(const QHostAddress &address)
@@ -300,7 +300,7 @@ QHostAddress CoapReply::hostAddress() const
     return m_hostAddress;
 }
 
-void CoapReply::setPort(const int &port)
+void CoapReply::setPort(int port)
 {
     m_port = port;
 }
@@ -320,12 +320,12 @@ QByteArray CoapReply::requestPayload() const
     return m_requestPayload;
 }
 
-void CoapReply::setRequestMethod(const CoapPdu::StatusCode &method)
+void CoapReply::setRequestMethod(CoapPdu::ReqRspCode method)
 {
     m_requestMethod = method;
 }
 
-CoapPdu::StatusCode CoapReply::requestMethod() const
+CoapPdu::ReqRspCode CoapReply::requestMethod() const
 {
     return m_requestMethod;
 }
@@ -352,7 +352,7 @@ QDebug operator<<(QDebug debug, CoapReply *reply)
     QMetaEnum messageTypeEnum = metaObject.enumerator(metaObject.indexOfEnumerator("MessageType"));
     QMetaEnum contentTypeEnum = metaObject.enumerator(metaObject.indexOfEnumerator("ContentType"));
     debug.nospace() << "CoapReply(" << messageTypeEnum.valueToKey(reply->messageType()) << ")" << endl;
-    debug.nospace() << "  Status code: " << CoapPdu::getStatusCodeString(reply->statusCode()) << endl;
+    debug.nospace() << "  Status code: " << CoapPdu::getReqRspCodeString(reply->reqRspCode()) << endl;
     debug.nospace() << "  Content type: " << contentTypeEnum.valueToKey(reply->contentType()) << endl;
     debug.nospace() << "  Payload size: " << reply->payload().size() << endl;
 

--- a/libnymea/coap/coapreply.h
+++ b/libnymea/coap/coapreply.h
@@ -66,7 +66,7 @@ public:
 
     CoapPdu::ContentType contentType() const;
     CoapPdu::MessageType messageType() const;
-    CoapPdu::StatusCode statusCode() const;
+    CoapPdu::ReqRspCode reqRspCode() const;
 
 private:
     CoapReply(const CoapRequest &request, QObject *parent = 0);
@@ -78,9 +78,9 @@ private:
 
     void resend();
 
-    void setContentType(const CoapPdu::ContentType contentType = CoapPdu::TextPlain);
-    void setMessageType(const CoapPdu::MessageType &messageType);
-    void setStatusCode(const CoapPdu::StatusCode &statusCode);
+    void setContentType(CoapPdu::ContentType contentType = CoapPdu::TextPlain);
+    void setMessageType(CoapPdu::MessageType messageType);
+    void setReqRspCode(CoapPdu::ReqRspCode reqRspCode);
 
     QTimer *m_timer;
     CoapRequest m_request;
@@ -93,20 +93,20 @@ private:
 
     CoapPdu::ContentType m_contentType;
     CoapPdu::MessageType m_messageType;
-    CoapPdu::StatusCode m_statusCode;
+    CoapPdu::ReqRspCode m_reqRspCode;
 
     // data for the request
     void setHostAddress(const QHostAddress &address);
     QHostAddress hostAddress() const;
 
-    void setPort(const int &port);
+    void setPort(int port);
     int port() const;
 
     void setRequestPayload(const QByteArray &requestPayload);
     QByteArray requestPayload() const;
 
-    void setRequestMethod(const CoapPdu::StatusCode &method);
-    CoapPdu::StatusCode requestMethod() const;
+    void setRequestMethod(CoapPdu::ReqRspCode method);
+    CoapPdu::ReqRspCode requestMethod() const;
 
     void setRequestData(const QByteArray &requestData);
     QByteArray requestData() const;
@@ -125,7 +125,7 @@ private:
 
     QHostAddress m_hostAddress;
     int m_port;
-    CoapPdu::StatusCode m_requestMethod;
+    CoapPdu::ReqRspCode m_requestMethod;
     QByteArray m_requestPayload;
     QByteArray m_requestData;
     bool m_lockedUp;

--- a/libnymea/coap/coaprequest.cpp
+++ b/libnymea/coap/coaprequest.cpp
@@ -44,7 +44,7 @@ CoapRequest::CoapRequest(const QUrl &url) :
     m_url(url),
     m_contentType(CoapPdu::TextPlain),
     m_messageType(CoapPdu::Confirmable),
-    m_statusCode(CoapPdu::Empty)
+    m_reqRspCode(CoapPdu::Empty)
 {
 }
 

--- a/libnymea/coap/coaprequest.h
+++ b/libnymea/coap/coaprequest.h
@@ -57,7 +57,7 @@ private:
     QUrl m_url;
     CoapPdu::ContentType m_contentType;
     CoapPdu::MessageType m_messageType;
-    CoapPdu::StatusCode m_statusCode;
+    CoapPdu::ReqRspCode m_reqRspCode;
 
 };
 


### PR DESCRIPTION
CoIoT is a shelly specific extensions to CoAP:
It adds a new Request code which is not part of the CoAP spec
as well as using CoAP multicast (which is part of CoAP).

This commit
* renames "statusCode" to "reqRspCode" which describes
the actual field more precisely as it is in fact a Request or Response
code, not a status code.
* Allows joining multicast groups, by default using the CoAP specified
multicast address.
* Allows setting custom Request codes in requests, as well as
processing the PDUs Request/response code by the client.
* does *not* add any shelly specific CoIoT stuff to the lib but opens
the API up so that the plugin can do the necessary things to implement
CoIoT on top.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
