### PR TITLE
Network device monitor ping multiple times

### DIFF
--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
@@ -378,6 +378,8 @@ void NetworkDeviceDiscoveryImpl::loadNetworkDeviceCache()
     }
     m_cacheSettings->endGroup(); // NetworkDeviceInfos
 
+    qCInfo(dcNetworkDeviceDiscovery()) << "Loaded" << m_networkInfoCache.count() << "network device infos from cache.";
+
     // We just did some housekeeping while loading from the cache
     m_lastCacheHousekeeping = QDateTime::currentDateTime();
 }

--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
@@ -603,7 +603,7 @@ void NetworkDeviceDiscoveryImpl::finishDiscovery()
     m_running = false;
     emit runningChanged(m_running);
 
-    emit networkDeviceInfoCacheUpdated();
+    emit cacheUpdated();
 
     m_lastDiscovery = QDateTime::currentDateTime();
 

--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
@@ -250,6 +250,11 @@ bool NetworkDeviceDiscoveryImpl::sendArpRequest(const QHostAddress &address)
     return false;
 }
 
+QHash<MacAddress, NetworkDeviceInfo> NetworkDeviceDiscoveryImpl::cache() const
+{
+    return m_networkInfoCache;
+}
+
 void NetworkDeviceDiscoveryImpl::setEnabled(bool enabled)
 {
     m_enabled = enabled;

--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.h
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.h
@@ -71,7 +71,7 @@ public:
     void unregisterMonitor(const MacAddress &macAddress) override;
     void unregisterMonitor(NetworkDeviceMonitor *networkDeviceMonitor) override;
 
-    PingReply *ping(const QHostAddress &address) override;
+    PingReply *ping(const QHostAddress &address, uint retries = 3) override;
 
     MacAddressDatabaseReply *lookupMacAddress(const QString &macAddress) override;
     MacAddressDatabaseReply *lookupMacAddress(const MacAddress &macAddress) override;

--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.h
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.h
@@ -78,6 +78,8 @@ public:
 
     bool sendArpRequest(const QHostAddress &address) override;
 
+    QHash<MacAddress, NetworkDeviceInfo> cache() const override;
+
 protected:
     void setEnabled(bool enabled) override;
 

--- a/libnymea-core/hardware/network/networkdevicemonitorimpl.cpp
+++ b/libnymea-core/hardware/network/networkdevicemonitorimpl.cpp
@@ -29,6 +29,9 @@
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "networkdevicemonitorimpl.h"
+#include "loggingcategories.h"
+
+Q_DECLARE_LOGGING_CATEGORY(dcNetworkDeviceDiscovery)
 
 namespace nymeaserver {
 
@@ -73,6 +76,7 @@ void NetworkDeviceMonitorImpl::setReachable(bool reachable)
     if (m_reachable == reachable)
         return;
 
+    qCDebug(dcNetworkDeviceDiscovery()) << this << (reachable ? "is now reachable" : "is not reachable any more.");
     m_reachable = reachable;
     emit reachableChanged(m_reachable);
 }
@@ -90,6 +94,26 @@ void NetworkDeviceMonitorImpl::setLastSeen(const QDateTime &lastSeen)
     m_lastSeen = lastSeen;
 
     emit lastSeenChanged(m_lastSeen);
+}
+
+uint NetworkDeviceMonitorImpl::pingRetries() const
+{
+    return m_pingRetries;
+}
+
+void NetworkDeviceMonitorImpl::setPingRetries(uint pingRetries)
+{
+    m_pingRetries = pingRetries;
+}
+
+PingReply *NetworkDeviceMonitorImpl::currentPingReply() const
+{
+    return m_currentPingReply;
+}
+
+void NetworkDeviceMonitorImpl::setCurrentPingReply(PingReply *reply)
+{
+    m_currentPingReply = reply;
 }
 
 QDateTime NetworkDeviceMonitorImpl::lastConnectionAttempt() const

--- a/libnymea-core/hardware/network/networkdevicemonitorimpl.h
+++ b/libnymea-core/hardware/network/networkdevicemonitorimpl.h
@@ -35,6 +35,7 @@
 #include <QDateTime>
 
 #include "network/networkdevicemonitor.h"
+#include "network/pingreply.h"
 
 namespace nymeaserver {
 
@@ -57,8 +58,15 @@ public:
     QDateTime lastSeen() const override;
     void setLastSeen(const QDateTime &lastSeen);
 
+    uint pingRetries() const override;
+    void setPingRetries(uint pingRetries) override;
+
+    PingReply *currentPingReply() const;
+    void setCurrentPingReply(PingReply *reply);
+
     QDateTime lastConnectionAttempt() const;
     void setLastConnectionAttempt(const QDateTime &lastConnectionAttempt);
+
 
 private:
     NetworkDeviceInfo m_networkDeviceInfo;
@@ -66,7 +74,8 @@ private:
     bool m_reachable = false;
     QDateTime m_lastSeen;
     QDateTime m_lastConnectionAttempt;
-
+    uint m_pingRetries = 5;
+    PingReply *m_currentPingReply = nullptr;
 };
 
 }

--- a/libnymea/network/networkdevicediscovery.h
+++ b/libnymea/network/networkdevicediscovery.h
@@ -71,7 +71,7 @@ public:
 
 signals:
     void runningChanged(bool running);
-    void networkDeviceInfoCacheUpdated();
+    void cacheUpdated();
 
 };
 

--- a/libnymea/network/networkdevicediscovery.h
+++ b/libnymea/network/networkdevicediscovery.h
@@ -60,7 +60,7 @@ public:
     virtual void unregisterMonitor(const MacAddress &macAddress) = 0;
     virtual void unregisterMonitor(NetworkDeviceMonitor *networkDeviceMonitor) = 0;
 
-    virtual PingReply *ping(const QHostAddress &address) = 0;
+    virtual PingReply *ping(const QHostAddress &address, uint retries = 3) = 0;
 
     virtual MacAddressDatabaseReply *lookupMacAddress(const QString &macAddress) = 0;
     virtual MacAddressDatabaseReply *lookupMacAddress(const MacAddress &macAddress) = 0;

--- a/libnymea/network/networkdevicediscovery.h
+++ b/libnymea/network/networkdevicediscovery.h
@@ -67,6 +67,8 @@ public:
 
     virtual bool sendArpRequest(const QHostAddress &address) = 0;
 
+    virtual QHash<MacAddress, NetworkDeviceInfo> cache() const = 0;
+
 signals:
     void runningChanged(bool running);
     void networkDeviceInfoCacheUpdated();

--- a/libnymea/network/networkdevicemonitor.h
+++ b/libnymea/network/networkdevicemonitor.h
@@ -53,6 +53,9 @@ public:
     virtual bool reachable() const = 0;
     virtual QDateTime lastSeen() const = 0;
 
+    virtual uint pingRetries() const = 0;
+    virtual void setPingRetries(uint pingRetries) = 0;
+
 signals:
     void reachableChanged(bool reachable);
     void lastSeenChanged(const QDateTime &lastSeen);

--- a/libnymea/network/ping.h
+++ b/libnymea/network/ping.h
@@ -62,7 +62,7 @@ public:
 
     PingReply::Error error() const;
 
-    PingReply *ping(const QHostAddress &hostAddress);
+    PingReply *ping(const QHostAddress &hostAddress, uint retries = 3);
 
 signals:
     void availableChanged(bool available);
@@ -76,6 +76,7 @@ private:
     // Config
     QByteArray m_payload = "ping from nymea";
     PingReply::Error m_error = PingReply::ErrorNoError;
+    uint m_timeoutDuration = 5000;
 
     // Socket
     QSocketNotifier *m_socketNotifier = nullptr;

--- a/libnymea/network/pingreply.cpp
+++ b/libnymea/network/pingreply.cpp
@@ -63,6 +63,16 @@ QNetworkInterface PingReply::networkInterface() const
     return m_networkInterface;
 }
 
+uint PingReply::retries() const
+{
+    return m_reties;
+}
+
+uint PingReply::retryCount() const
+{
+    return m_retryCount;
+}
+
 double PingReply::duration() const
 {
     return m_duration;
@@ -71,4 +81,11 @@ double PingReply::duration() const
 PingReply::Error PingReply::error() const
 {
     return m_error;
+}
+
+void PingReply::abort()
+{
+    m_timer->stop();
+    m_error = ErrorAborted;
+    emit aborted();
 }

--- a/libnymea/network/pingreply.h
+++ b/libnymea/network/pingreply.h
@@ -51,6 +51,7 @@ class LIBNYMEA_EXPORT PingReply : public QObject
 public:
     enum Error {
         ErrorNoError,
+        ErrorAborted,
         ErrorInvalidResponse,
         ErrorNetworkDown,
         ErrorNetworkUnreachable,
@@ -70,13 +71,21 @@ public:
     QString hostName() const;
     QNetworkInterface networkInterface() const;
 
+    uint retries() const;
+    uint retryCount() const;
+
     double duration() const;
 
     Error error() const;
 
+public slots:
+    void abort();
+
 signals:
     void finished();
     void timeout();
+    void retry(Error error, uint retryCount);
+    void aborted();
 
 private:
     QTimer *m_timer = nullptr;
@@ -86,6 +95,8 @@ private:
     QString m_hostName;
     QNetworkInterface m_networkInterface;
 
+    uint m_reties = 0;
+    uint m_retryCount = 0;
     uint m_timeout = 3;
     double m_duration = 0;
     Error m_error = ErrorNoError;


### PR DESCRIPTION
While trying to find the crash with the invalid PingReply access (which I did not manage to find yet),
I've stumbled across some other minor things.

* Fixes a theoretical memory leak (m_cacheSettings wasn't deleted) which isn't really an issue in practice but valgrind complains on it.
*  Fixes a typo: m_reties -> m_retries




nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
