### PR TITLE
Smaller fixes in the NetworkDiscovery

### DIFF
--- a/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
+++ b/libnymea-core/hardware/network/networkdevicediscoveryimpl.cpp
@@ -93,7 +93,7 @@ NetworkDeviceDiscoveryImpl::NetworkDeviceDiscoveryImpl(QObject *parent) :
 
 NetworkDeviceDiscoveryImpl::~NetworkDeviceDiscoveryImpl()
 {
-
+    delete m_cacheSettings;
 }
 
 NetworkDeviceDiscoveryReply *NetworkDeviceDiscoveryImpl::discover()

--- a/libnymea/network/ping.cpp
+++ b/libnymea/network/ping.cpp
@@ -116,7 +116,7 @@ PingReply *Ping::ping(const QHostAddress &hostAddress, uint retries)
     PingReply *reply = new PingReply(this);
     reply->m_targetHostAddress = hostAddress;
     reply->m_networkInterface = NetworkUtils::getInterfaceForHostaddress(hostAddress);
-    reply->m_reties = retries;
+    reply->m_retries = retries;
 
     connect(reply, &PingReply::timeout, this, [=](){
         // Note: this is not the ICMP timeout, here we actually got nothing from nobody...
@@ -297,7 +297,7 @@ quint16 Ping::calculateRequestId()
 void Ping::finishReply(PingReply *reply, PingReply::Error error)
 {
     // Check if we should retry
-    if (reply->m_retryCount >= reply->m_reties ||
+    if (reply->m_retryCount >= reply->m_retries ||
             error == PingReply::ErrorNoError ||
             error == PingReply::ErrorAborted ||
             error == PingReply::ErrorInvalidHostAddress ||
@@ -314,7 +314,7 @@ void Ping::finishReply(PingReply *reply, PingReply::Error error)
         reply->m_retryCount++;
         reply->m_sequenceNumber++;
 
-        qCDebug(dcPing()) << "Ping finished with error" << error << "Retry ping" << reply->targetHostAddress().toString() << reply->m_retryCount << "/" << reply->m_reties;
+        qCDebug(dcPing()) << "Ping finished with error" << error << "Retry ping" << reply->targetHostAddress().toString() << reply->m_retryCount << "/" << reply->m_retries;
         emit reply->retry(error, reply->retryCount());
 
         // Note: will be restarted once actually sent trough the network

--- a/libnymea/network/pingreply.cpp
+++ b/libnymea/network/pingreply.cpp
@@ -65,7 +65,7 @@ QNetworkInterface PingReply::networkInterface() const
 
 uint PingReply::retries() const
 {
-    return m_reties;
+    return m_retries;
 }
 
 uint PingReply::retryCount() const

--- a/libnymea/network/pingreply.h
+++ b/libnymea/network/pingreply.h
@@ -95,7 +95,7 @@ private:
     QString m_hostName;
     QNetworkInterface m_networkInterface;
 
-    uint m_reties = 0;
+    uint m_retries = 0;
     uint m_retryCount = 0;
     uint m_timeout = 3;
     double m_duration = 0;


### PR DESCRIPTION
While trying to find the crash with the invalid PingReply access (which I did not manage to find yet),
I've stumbled across some other minor things:


Fixes a theoretical memory leak (m_cacheSettings wasn't delete)
which isn't really an issue in practice but valgrind complains on it.

Fixes a typo: m_reties -> m_retries

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
