### PR TITLE
Silence another valgrind leak complaint

### DIFF
--- a/libnymea-core/integrations/translator.cpp
+++ b/libnymea-core/integrations/translator.cpp
@@ -47,7 +47,7 @@ Translator::~Translator()
 {
     foreach (const TranslatorContext &ctx, m_translatorContexts) {
         foreach (QTranslator *t, ctx.translators) {
-            t->deleteLater();
+            delete t;
         }
     }
     m_translatorContexts.clear();


### PR DESCRIPTION
When tearing down, deleteLater() doesn't make so much sense and
valgrind doesn't like that - fair enough...

nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
