### PR TITLE
Fix additional interface command line parameter

### DIFF
--- a/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
+++ b/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
@@ -76,7 +76,7 @@ signals:
 
     // Server API
 public:
-    void registerTransportInterface(TransportInterface *interface, bool authenticationRequired);
+    void registerTransportInterface(TransportInterface *interface);
     void unregisterTransportInterface(TransportInterface *interface);
 
     bool registerHandler(JsonHandler *handler) override;
@@ -111,7 +111,6 @@ private slots:
 private:
     QVariantMap m_api;
     QHash<JsonHandler*, QString> m_experiences;
-    QMap<TransportInterface*, bool> m_interfaces; // Interface, authenticationRequired
     QHash<QString, JsonHandler *> m_handlers;
     QHash<JsonReply *, TransportInterface *> m_asyncReplies;
 

--- a/libnymea-core/nymeacore.cpp
+++ b/libnymea-core/nymeacore.cpp
@@ -158,7 +158,7 @@ void NymeaCore::init(const QStringList &additionalInterfaces) {
     m_thingManager->registerStaticPlugin(cloudNotifications);
 
     CloudTransport *cloudTransport = m_cloudManager->createTransportInterface();
-    m_serverManager->jsonServer()->registerTransportInterface(cloudTransport, false);
+    m_serverManager->jsonServer()->registerTransportInterface(cloudTransport);
 
     connect(m_configuration, &NymeaConfiguration::serverNameChanged, m_serverManager, &ServerManager::setServerName);
 

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
     QCommandLineOption debugOption(QStringList() << "d" << "debug-category", debugDescription, "[No]DebugCategory[Warnings]");
     parser.addOption(debugOption);
 
-    QCommandLineOption interfacesOption({"i", "interface"}, QCoreApplication::translate("nymea", "Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777)."));
+    QCommandLineOption interfacesOption({"i", "interface"}, QCoreApplication::translate("nymea", "Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only."), "interfaceString");
     parser.addOption(interfacesOption);
 
     parser.process(application);


### PR DESCRIPTION
Fixes the additional interface parameter.

Also removes the redundant authenticationRequired parameter for the `registerTransportInterface()` method. The code was using a mix of that parameter and the authenticationEnabled option in the transports config which was causing bugs if they didn't line up.

Now the code uses only the value in the transports config.


nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
