### PR TITLE
Check Info objects for finished after aborting them

### DIFF
--- a/libnymea/integrations/browseractioninfo.cpp
+++ b/libnymea/integrations/browseractioninfo.cpp
@@ -46,7 +46,9 @@ BrowserActionInfo::BrowserActionInfo(Thing *thing, ThingManager *thingManager, c
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/browseresult.cpp
+++ b/libnymea/integrations/browseresult.cpp
@@ -47,7 +47,9 @@ BrowseResult::BrowseResult(Thing *thing, ThingManager *thingManager, const QStri
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/browseritemactioninfo.cpp
+++ b/libnymea/integrations/browseritemactioninfo.cpp
@@ -46,7 +46,9 @@ BrowserItemActionInfo::BrowserItemActionInfo(Thing *thing, ThingManager *thingMa
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/browseritemresult.cpp
+++ b/libnymea/integrations/browseritemresult.cpp
@@ -47,7 +47,9 @@ BrowserItemResult::BrowserItemResult(Thing *thing, ThingManager *thingManager, c
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/thingactioninfo.cpp
+++ b/libnymea/integrations/thingactioninfo.cpp
@@ -47,7 +47,9 @@ ThingActionInfo::ThingActionInfo(Thing *thing, const Action &action, ThingManage
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/thingdiscoveryinfo.cpp
+++ b/libnymea/integrations/thingdiscoveryinfo.cpp
@@ -46,7 +46,9 @@ ThingDiscoveryInfo::ThingDiscoveryInfo(const ThingClassId &thingClassId, const P
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/thingpairinginfo.cpp
+++ b/libnymea/integrations/thingpairinginfo.cpp
@@ -49,7 +49,9 @@ ThingPairingInfo::ThingPairingInfo(const PairingTransactionId &pairingTransactio
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }

--- a/libnymea/integrations/thingsetupinfo.cpp
+++ b/libnymea/integrations/thingsetupinfo.cpp
@@ -47,7 +47,9 @@ ThingSetupInfo::ThingSetupInfo(Thing *thing, ThingManager *thingManager, quint32
     if (timeout > 0) {
         QTimer::singleShot(timeout, this, [this] {
             emit aborted();
-            finish(Thing::ThingErrorTimeout);
+            if (!m_finished) {
+                finish(Thing::ThingErrorTimeout);
+            }
         });
     }
 }


### PR DESCRIPTION
This gives plugin developers a chance to finish() an info on their
own in an aborted() handler and set a custom error code and
displayMessage without causing a "finishing an already finished object"
warning.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
