### PR TITLE
Fix a python plugin crash when trying to login with empty credentials

### DIFF
--- a/libnymea-core/integrations/pythonintegrationplugin.cpp
+++ b/libnymea-core/integrations/pythonintegrationplugin.cpp
@@ -505,8 +505,9 @@ void PythonIntegrationPlugin::confirmPairing(ThingPairingInfo *info, const QStri
         PyEval_ReleaseThread(m_threadState);
     });
 
-    PyObject *pyUsername = PyUnicode_FromString(username.toUtf8().data());
-    PyObject *pySecret = PyUnicode_FromString(secret.toUtf8().data());
+    // PyUnicode_FromString crashes on empty strings. Creating a new empty python string instead.
+    PyObject *pyUsername = username.isEmpty() ? PyUnicode_New(1, 127) : PyUnicode_FromString(username.toUtf8().data());
+    PyObject *pySecret = secret.isEmpty() ? PyUnicode_New(1, 127) : PyUnicode_FromString(secret.toUtf8().data());
     bool result = callPluginFunction("confirmPairing", reinterpret_cast<PyObject*>(pyInfo), pyUsername, pySecret);
     if (!result) {
         info->finish(Thing::ThingErrorHardwareFailure, "Plugin error: " + pluginName());


### PR DESCRIPTION
nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
