### PR TITLE
Add optional boost state to thermostats

### DIFF
--- a/libnymea/interfaces/thermostat.json
+++ b/libnymea/interfaces/thermostat.json
@@ -24,6 +24,11 @@
             "name": "coolingOn",
             "type": "bool",
             "optional": true
+        },
+        {
+            "name": "boost",
+            "type": "bool",
+            "optional": true
         }
     ]
 }


### PR DESCRIPTION
nymea:app already implements this and many plugins do too. Apparently
most of the radiator thermostats support this, so it's worth making it
part of the interface.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
