### PR TITLE
Bind a client connection to the token given in the hello call.

### DIFF
--- a/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
+++ b/libnymea-core/jsonrpc/jsonrpcserverimplementation.h
@@ -113,6 +113,7 @@ private:
     QHash<QUuid, QByteArray> m_clientBuffers;
     QHash<QUuid, QStringList> m_clientNotifications;
     QHash<QUuid, QLocale> m_clientLocales;
+    QHash<QUuid, QByteArray> m_clientTokens;
     QHash<int, QUuid> m_pushButtonTransactions;
     QHash<QUuid, QTimer*> m_newConnectionWaitTimers;
 

--- a/libnymea-core/usermanager/usermanager.cpp
+++ b/libnymea-core/usermanager/usermanager.cpp
@@ -164,6 +164,7 @@ UserManager::UserError UserManager::createUser(const QString &username, const QS
 
     QSqlQuery checkForDuplicateUserQuery(m_db);
     checkForDuplicateUserQuery.prepare("SELECT * FROM users WHERE lower(username) = ?;");
+    // Note: We're using toLower() on the username mainly for the reason that in old versions the username used to be an email address
     checkForDuplicateUserQuery.addBindValue(username.toLower());
     checkForDuplicateUserQuery.exec();
     if (checkForDuplicateUserQuery.first()) {

--- a/tests/auto/websocketserver/testwebsocketserver.cpp
+++ b/tests/auto/websocketserver/testwebsocketserver.cpp
@@ -83,7 +83,7 @@ void TestWebSocketServer::initTestCase()
     config.address = "127.0.0.1";
     config.port = 4444;
     config.sslEnabled = true;
-    config.authenticationEnabled = true;
+    config.authenticationEnabled = false;
     NymeaCore::instance()->configuration()->setWebSocketServerConfiguration(config);
 
 }

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -87,6 +87,11 @@ void NymeaTestBase::initTestCase(const QString &loggingRules)
     qApp->processEvents();
     qCDebug(dcTests()) << "Nymea core instance initialized. Creating dummy user.";
 
+    foreach (const UserInfo &userInfo, NymeaCore::instance()->userManager()->users()) {
+        NymeaCore::instance()->userManager()->removeUser(userInfo.username());
+    }
+    NymeaCore::instance()->userManager()->removeUser("");
+
     // Yes, we're intentionally mixing upper/lower case email here... username should not be case sensitive
     NymeaCore::instance()->userManager()->removeUser("dummy");
     NymeaCore::instance()->userManager()->createUser("dummy", "DummyPW1!", "dummy@guh.io", "Dummy", Types::PermissionScopeAdmin);
@@ -128,13 +133,13 @@ void NymeaTestBase::cleanup()
     }
 }
 
-QVariant NymeaTestBase::injectAndWait(const QString &method, const QVariantMap &params, const QUuid &clientId)
+QVariant NymeaTestBase::injectAndWait(const QString &method, const QVariantMap &params, const QUuid &clientId, const QByteArray &tokenOverride)
 {
     QVariantMap call;
     call.insert("id", m_commandId);
     call.insert("method", method);
     call.insert("params", params);
-    call.insert("token", m_apiToken);
+    call.insert("token", tokenOverride == "default" ? m_apiToken : tokenOverride);
 
     QJsonDocument jsonDoc = QJsonDocument::fromVariant(call);
     QSignalSpy spy(m_mockTcpServer, SIGNAL(outgoingData(QUuid,QByteArray)));

--- a/tests/testlib/nymeatestbase.h
+++ b/tests/testlib/nymeatestbase.h
@@ -56,7 +56,7 @@ protected slots:
     void cleanup();
 
 protected:
-    QVariant injectAndWait(const QString &method, const QVariantMap &params = QVariantMap(), const QUuid &clientId = QUuid());
+    QVariant injectAndWait(const QString &method, const QVariantMap &params = QVariantMap(), const QUuid &clientId = QUuid(), const QByteArray &tokenOverride = "default");
     QVariant checkNotification(const QSignalSpy &spy, const QString &notification);
     QVariantList checkNotifications(const QSignalSpy &spy, const QString &notification);
 


### PR DESCRIPTION
This is a prerequisite for enabling dispatching notifications based on user permissions.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
