### PR TITLE
Add names to actions

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -1320,9 +1320,17 @@ ThingActionInfo *ThingManagerImplementation::executeAction(const Action &action)
 
     // Make sure this thing has an action type with this id
     ThingClass thingClass = findThingClass(thing->thingClassId());
-    ActionType actionType = thingClass.actionTypes().findById(action.actionTypeId());
-    if (actionType.id().isNull()) {
-        qCWarning(dcThingManager()) << "Cannot execute action on" << thing << "No ActionType with ID" << action.actionTypeId();
+    ActionType actionType;
+    if (!action.actionName().isEmpty()) {
+        actionType = thingClass.actionTypes().findByName(action.actionName());
+        finalAction.setActionTypeId(actionType.id());
+    } else {
+        actionType = thingClass.actionTypes().findById(action.actionTypeId());
+        finalAction.setActionName(actionType.name());
+    }
+
+    if (actionType.name().isEmpty()) {
+        qCWarning(dcThingManager()) << "Cannot execute action on" << thing << "No ActionType with name" << action.actionName() << "or ID" << action.actionTypeId();
         ThingActionInfo *info = new ThingActionInfo(thing, action, this);
         info->finish(Thing::ThingErrorActionTypeNotFound);
         return info;
@@ -1339,7 +1347,7 @@ ThingActionInfo *ThingManagerImplementation::executeAction(const Action &action)
     // If there's a stateType with the same id, we'll need to take min/max values from the state as
     // they might change at runtime
     ParamTypes paramTypes = actionType.paramTypes();
-    StateType stateType = thingClass.stateTypes().findById(action.actionTypeId());
+    StateType stateType = thingClass.stateTypes().findByName(actionType.name());
     if (!stateType.id().isNull()) {
         ParamType pt = actionType.paramTypes().at(0);
         pt.setMinValue(thing->state(stateType.id()).minValue());

--- a/libnymea-core/jsonrpc/integrationshandler.cpp
+++ b/libnymea-core/jsonrpc/integrationshandler.cpp
@@ -345,8 +345,9 @@ IntegrationsHandler::IntegrationsHandler(ThingManager *thingManager, QObject *pa
 
     params.clear(); returns.clear();
     description = "Execute a single action.";
-    params.insert("actionTypeId", enumValueName(Uuid));
     params.insert("thingId", enumValueName(Uuid));
+    params.insert("o:actionName", enumValueName(String));
+    params.insert("d:o:actionTypeId", enumValueName(Uuid));
     params.insert("o:params", objectRef<ParamList>());
     returns.insert("thingError", enumRef<Thing::ThingError>());
     returns.insert("o:displayMessage", enumValueName(String));
@@ -1029,11 +1030,19 @@ JsonReply *IntegrationsHandler::GetBrowserItem(const QVariantMap &params, const 
 JsonReply *IntegrationsHandler::ExecuteAction(const QVariantMap &params, const JsonContext &context)
 {
     ThingId thingId(params.value("thingId").toString());
+    QString actionName = params.value("actionName").toString();
     ActionTypeId actionTypeId(params.value("actionTypeId").toString());
     ParamList actionParams = unpack<ParamList>(params.value("params"));
     QLocale locale = context.locale();
 
-    Action action(actionTypeId, thingId);
+    Action action;
+    if (!actionName.isEmpty()) {
+        action.setActionName(actionName);
+    } else {
+        action.setActionTypeId(actionTypeId);
+    }
+
+    action.setThingId(thingId);
     action.setParams(actionParams);
 
     JsonReply *jsonReply = createAsyncReply("ExecuteAction");

--- a/libnymea/types/action.cpp
+++ b/libnymea/types/action.cpp
@@ -53,6 +53,14 @@ Action::Action(const ActionTypeId &actionTypeId, const ThingId &thingId, Trigger
 {
 }
 
+Action::Action(const ThingId &thingId, const QString &actionName, TriggeredBy triggeredBy):
+    m_thingId(thingId),
+    m_actionName(actionName),
+    m_triggeredBy(triggeredBy)
+{
+
+}
+
 /*! Construct a copy of an \a other Action. */
 Action::Action(const Action &other):
     m_actionTypeId(other.actionTypeId()),
@@ -88,6 +96,16 @@ ThingId Action::thingId() const
 void Action::setThingId(const ThingId &thingId)
 {
     m_thingId = thingId;
+}
+
+QString Action::actionName() const
+{
+    return m_actionName;
+}
+
+void Action::setActionName(const QString &actionName)
+{
+    m_actionName = actionName;
 }
 
 /*! Returns the parameters for this Action. */

--- a/libnymea/types/action.h
+++ b/libnymea/types/action.h
@@ -40,8 +40,9 @@
 class LIBNYMEA_EXPORT Action
 {
     Q_GADGET
-    Q_PROPERTY(QUuid actionTypeId READ actionTypeId WRITE setActionTypeId)
+    Q_PROPERTY(QUuid actionTypeId READ actionTypeId WRITE setActionTypeId USER true REVISION 1)
     Q_PROPERTY(QUuid thingId READ thingId WRITE setThingId)
+    Q_PROPERTY(QString actionName READ actionName WRITE setActionName USER true) // TODO: make mandatory when deprecated actionTypeId is removed
     Q_PROPERTY(ParamList params READ params WRITE setParams USER true)
 
 public:
@@ -50,7 +51,8 @@ public:
         TriggeredByRule,
         TriggeredByScript
     };
-    explicit Action(const ActionTypeId &actionTypeId = ActionTypeId(), const ThingId &thingId = ThingId(), TriggeredBy triggeredBy = TriggeredByUser);
+    explicit Action(const ActionTypeId &actionTypeId, const ThingId &thingId = ThingId(), TriggeredBy triggeredBy = TriggeredByUser);
+    explicit Action(const ThingId &thingId = ThingId(), const QString &actionName = QString(), TriggeredBy triggeredBy = TriggeredByUser);
     Action(const Action &other);
 
     bool isValid() const;
@@ -59,6 +61,8 @@ public:
     void setActionTypeId(const ActionTypeId &actionTypeId);
     ThingId thingId() const;
     void setThingId(const ThingId &thingId);
+    QString actionName() const;
+    void setActionName(const QString &actionName);
 
     ParamList params() const;
     void setParams(const ParamList &params);
@@ -71,6 +75,7 @@ public:
 private:
     ActionTypeId m_actionTypeId;
     ThingId m_thingId;
+    QString m_actionName;
     ParamList m_params;
     TriggeredBy m_triggeredBy = TriggeredByUser;
 };


### PR DESCRIPTION
This allows executing actions by name and marks actionTypeId in action as deprecated.

nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
