### PR TITLE
Make init call for python plugins blocking

### DIFF
--- a/libnymea-core/integrations/pythonintegrationplugin.cpp
+++ b/libnymea-core/integrations/pythonintegrationplugin.cpp
@@ -441,6 +441,13 @@ void PythonIntegrationPlugin::init()
     m_mutex.unlock();
 
     callPluginFunction("init");
+
+    // Waiting for the init to finish. In case a plugin needs to do some more stuff in init we don't
+    // want to run setupThing() before the init finishes.
+    if (m_runningTasks.values().contains("init")) {
+        QFutureWatcher<void> *watcher = m_runningTasks.key("init");
+        watcher->waitForFinished();
+    }
 }
 
 void PythonIntegrationPlugin::startMonitoringAutoThings()


### PR DESCRIPTION
We don't want to run setupThing() before init() is completed. This also matches with how C++ plugins work.

Fixes #598

nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
