### PR TITLE
Fix a crash when the same plugin file is loaded twice

### DIFF
--- a/libnymea-core/integrations/thingmanagerimplementation.cpp
+++ b/libnymea-core/integrations/thingmanagerimplementation.cpp
@@ -1426,7 +1426,11 @@ void ThingManagerImplementation::loadPlugins()
 
             if (m_integrationPlugins.contains(plugin->pluginId())) {
                 qCWarning(dcThingManager()) << "A plugin with this ID is already loaded. Not loading" << entry << plugin->pluginId();
-                delete plugin;
+                // Depending on the plugin type, duplicate loading of the same plugin file may return the same instance. In which
+                // case we do *not* want to delete it, but we want to delete the dupe if a new instance has been created with the same ID.
+                if (m_integrationPlugins.value(plugin->pluginId()) != plugin) {
+                    delete plugin;
+                }
                 continue;
             }
             loadPlugin(plugin);

--- a/tests/testlib/nymeatestbase.cpp
+++ b/tests/testlib/nymeatestbase.cpp
@@ -220,7 +220,7 @@ QVariantList NymeaTestBase::checkNotifications(const QSignalSpy &spy, const QStr
 QVariant NymeaTestBase::getAndWait(const QNetworkRequest &request, const int &expectedStatus)
 {
     QNetworkAccessManager nam;
-    connect(&nam, &QNetworkAccessManager::sslErrors, [&nam](QNetworkReply *reply, const QList<QSslError> &) {
+    connect(&nam, &QNetworkAccessManager::sslErrors, [](QNetworkReply *reply, const QList<QSslError> &) {
         reply->ignoreSslErrors();
     });
     QSignalSpy clientSpy(&nam, SIGNAL(finished(QNetworkReply*)));
@@ -258,7 +258,7 @@ QVariant NymeaTestBase::getAndWait(const QNetworkRequest &request, const int &ex
 QVariant NymeaTestBase::deleteAndWait(const QNetworkRequest &request, const int &expectedStatus)
 {
     QNetworkAccessManager nam;
-    connect(&nam, &QNetworkAccessManager::sslErrors, [this, &nam](QNetworkReply *reply, const QList<QSslError> &) {
+    connect(&nam, &QNetworkAccessManager::sslErrors, [](QNetworkReply *reply, const QList<QSslError> &) {
         reply->ignoreSslErrors();
     });
     QSignalSpy clientSpy(&nam, SIGNAL(finished(QNetworkReply*)));
@@ -293,7 +293,7 @@ QVariant NymeaTestBase::deleteAndWait(const QNetworkRequest &request, const int 
 QVariant NymeaTestBase::postAndWait(const QNetworkRequest &request, const QVariant &params, const int &expectedStatus)
 {
     QNetworkAccessManager nam;
-    connect(&nam, &QNetworkAccessManager::sslErrors, [this, &nam](QNetworkReply *reply, const QList<QSslError> &) {
+    connect(&nam, &QNetworkAccessManager::sslErrors, [](QNetworkReply *reply, const QList<QSslError> &) {
         reply->ignoreSslErrors();
     });
     QSignalSpy clientSpy(&nam, SIGNAL(finished(QNetworkReply*)));
@@ -333,7 +333,7 @@ QVariant NymeaTestBase::postAndWait(const QNetworkRequest &request, const QVaria
 QVariant NymeaTestBase::putAndWait(const QNetworkRequest &request, const QVariant &params, const int &expectedStatus)
 {
     QNetworkAccessManager nam;
-    connect(&nam, &QNetworkAccessManager::sslErrors, [this, &nam](QNetworkReply *reply, const QList<QSslError> &) {
+    connect(&nam, &QNetworkAccessManager::sslErrors, [](QNetworkReply *reply, const QList<QSslError> &) {
         reply->ignoreSslErrors();
     });
     QSignalSpy clientSpy(&nam, SIGNAL(finished(QNetworkReply*)));


### PR DESCRIPTION
If the same directory is passed twice QPluginLoader would return the same object for the instance() call. Deleting that would lead to deleting the instance for the originally loaded plugin too.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
