### PR TITLE
Improve debug logging filter arguments

### DIFF
--- a/plugins/mock/translations/727a4a9a-c187-446f-aadf-f1b2220607d1-de.ts
+++ b/plugins/mock/translations/727a4a9a-c187-446f-aadf-f1b2220607d1-de.ts
@@ -53,87 +53,37 @@
     </message>
     <message>
         <source>Bool</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: bool, ID: {3bad3a09-5826-4ed7-a832-10e3e2ee2a7d})
-----------
-The name of the StateType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
         <translation>Boolscher Wert</translation>
     </message>
     <message>
-        <source>Bool changed</source>
-        <extracomment>The name of the EventType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
-        <translation>Boolscher Wert geändert</translation>
-    </message>
-    <message>
         <source>Color</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: color, ID: {4507d5c6-b692-4bd6-87f2-00364bc0cb4d})
-----------
-The name of the StateType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
         <translation>Farbe</translation>
     </message>
     <message>
-        <source>Color changed</source>
-        <extracomment>The name of the EventType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
-        <translation>Farbe geändert</translation>
-    </message>
-    <message>
         <source>Double</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: double, ID: {f7d2063d-959e-46ac-8568-8b99722d3b22})
-----------
-The name of the StateType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
         <translation>Gleitkommazahl</translation>
     </message>
     <message>
-        <source>Double changed</source>
-        <extracomment>The name of the EventType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
-        <translation>Gleitkommazahl geändert</translation>
-    </message>
-    <message>
         <source>Dummy bool state</source>
-        <extracomment>The name of the ParamType (ThingClass: autoMock, EventType: boolValue, ID: {978b0ba5-d008-41bd-b63d-a3bd23cb6469})
-----------
-The name of the StateType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
-----------
-The name of the ParamType (ThingClass: mock, EventType: bool, ID: {9dd6a97c-dfd1-43dc-acbd-367932742310})
+        <extracomment>The name of the StateType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
 ----------
 The name of the StateType ({9dd6a97c-dfd1-43dc-acbd-367932742310}) of ThingClass mock</extracomment>
         <translation>Simulierter boolscher Zustand</translation>
     </message>
     <message>
-        <source>Dummy bool state changed</source>
-        <extracomment>The name of the EventType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
-----------
-The name of the EventType ({9dd6a97c-dfd1-43dc-acbd-367932742310}) of ThingClass mock</extracomment>
-        <translation>Simulierter boolscher Zustand geändert</translation>
-    </message>
-    <message>
         <source>Dummy double state</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: double, ID: {7cac53ee-7048-4dc9-b000-7b585390f34c})
-----------
-The name of the StateType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
+        <extracomment>The name of the StateType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
         <translation>Simulierter Gleitkommazahl-Zustand</translation>
     </message>
     <message>
-        <source>Dummy double state changed</source>
-        <extracomment>The name of the EventType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
-        <translation>Simulierter Gleitkommazahl-Zustand geändert</translation>
-    </message>
-    <message>
         <source>Dummy int state</source>
-        <extracomment>The name of the ParamType (ThingClass: autoMock, EventType: int, ID: {74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c})
-----------
-The name of the StateType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
-----------
-The name of the ParamType (ThingClass: mock, EventType: int, ID: {80baec19-54de-4948-ac46-31eabfaceb83})
+        <extracomment>The name of the StateType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
 ----------
 The name of the StateType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass mock</extracomment>
         <translation>Simulierter Integer Zustand</translation>
-    </message>
-    <message>
-        <source>Dummy int state changed</source>
-        <extracomment>The name of the EventType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
-----------
-The name of the EventType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass mock</extracomment>
-        <translation>Simulierter Integer Zustand geändert</translation>
     </message>
     <message>
         <source>IPv4 address</source>
@@ -147,15 +97,8 @@ The name of the EventType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass
     </message>
     <message>
         <source>Int</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: int, ID: {d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb})
-----------
-The name of the StateType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
         <translation>Ganzzahl</translation>
-    </message>
-    <message>
-        <source>Int changed</source>
-        <extracomment>The name of the EventType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
-        <translation>Ganzzahl geändert</translation>
     </message>
     <message>
         <source>Mac address</source>
@@ -397,15 +340,8 @@ The name of the ActionType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClas
     </message>
     <message>
         <source>String</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: string, ID: {27f69ca9-a321-40ff-bfee-4b0272a671b4})
-----------
-The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
         <translation>Zeichenkette</translation>
-    </message>
-    <message>
-        <source>String changed</source>
-        <extracomment>The name of the EventType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
-        <translation>Zeichenkette gändert</translation>
     </message>
     <message>
         <source>Text area</source>
@@ -419,15 +355,8 @@ The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass
     </message>
     <message>
         <source>Time</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: time, ID: {8250c71e-59bc-41ab-b576-99fcfc34e8d1})
-----------
-The name of the StateType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
         <translation>Zeit</translation>
-    </message>
-    <message>
-        <source>Time changed</source>
-        <extracomment>The name of the EventType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
-        <translation>Zeit geändert</translation>
     </message>
     <message>
         <source>Timeout action</source>
@@ -438,39 +367,18 @@ The name of the ActionType ({54646e7c-bc54-4895-81a2-590d72d120f9}) of ThingClas
     </message>
     <message>
         <source>Timestamp (Int)</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: timestampInt, ID: {2c91b5ef-c2d1-4367-bc65-5a13abf69641})
-----------
-The name of the StateType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
         <translation>Zeitstempel (Int)</translation>
     </message>
     <message>
-        <source>Timestamp (Int) changed</source>
-        <extracomment>The name of the EventType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
-        <translation>Zeitstempel (Int) geändert</translation>
-    </message>
-    <message>
         <source>Timestamp (UInt)</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: timestampUInt, ID: {6c9a96e8-0d48-4f42-8967-848358fd7f79})
-----------
-The name of the StateType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
         <translation>Zeitstempel (UInt)</translation>
     </message>
     <message>
-        <source>Timestamp (UInt) changed</source>
-        <extracomment>The name of the EventType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
-        <translation>Zeitstempel (UInt) geändert</translation>
-    </message>
-    <message>
         <source>UInt</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: uint, ID: {19e74fcc-bfd5-491f-8eb6-af128e8f1162})
-----------
-The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
         <translation>UInt</translation>
-    </message>
-    <message>
-        <source>UInt changed</source>
-        <extracomment>The name of the EventType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
-        <translation>UInt geändert</translation>
     </message>
     <message>
         <source>URL</source>
@@ -481,35 +389,19 @@ The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass
         <source>Writable Bool</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableBool, ID: {a7c11774-f31f-4d64-99d1-e0ae5fb35a5c})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableBool, ID: {a7c11774-f31f-4d64-99d1-e0ae5fb35a5c})
-----------
 The name of the StateType ({a7c11774-f31f-4d64-99d1-e0ae5fb35a5c}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbarer boolscher Wert</translation>
-    </message>
-    <message>
-        <source>Writable Bool changed</source>
-        <extracomment>The name of the EventType ({a7c11774-f31f-4d64-99d1-e0ae5fb35a5c}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbarer Boolscher Wert geändert</translation>
     </message>
     <message>
         <source>Writable Color</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableColor, ID: {455f4f68-3cb0-4e8a-a707-62e4a2a8035c})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableColor, ID: {455f4f68-3cb0-4e8a-a707-62e4a2a8035c})
-----------
 The name of the StateType ({455f4f68-3cb0-4e8a-a707-62e4a2a8035c}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Farbe</translation>
     </message>
     <message>
-        <source>Writable Color changed</source>
-        <extracomment>The name of the EventType ({455f4f68-3cb0-4e8a-a707-62e4a2a8035c}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Farbe geändert</translation>
-    </message>
-    <message>
         <source>Writable Double</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableDouble, ID: {8e2eb91b-d60b-4461-9a50-d7b8ad263170})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableDouble, ID: {8e2eb91b-d60b-4461-9a50-d7b8ad263170})
 ----------
 The name of the StateType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Gleitkommazahl</translation>
@@ -518,26 +410,12 @@ The name of the StateType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass
         <source>Writable Double (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableDoubleMinMax, ID: {00d3425e-1da6-4748-8906-4555ceefb136})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableDoubleMinMax, ID: {00d3425e-1da6-4748-8906-4555ceefb136})
-----------
 The name of the StateType ({00d3425e-1da6-4748-8906-4555ceefb136}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Gleitkommazah (min/max)</translation>
     </message>
     <message>
-        <source>Writable Double (min/max) changed</source>
-        <extracomment>The name of the EventType ({00d3425e-1da6-4748-8906-4555ceefb136}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Gleitkommazahl (min/max) geändert</translation>
-    </message>
-    <message>
-        <source>Writable Double changed</source>
-        <extracomment>The name of the EventType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Gleitkommazahl geändert</translation>
-    </message>
-    <message>
         <source>Writable Int</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableInt, ID: {857a8422-983c-47d6-a15f-d8450b3162f7})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableInt, ID: {857a8422-983c-47d6-a15f-d8450b3162f7})
 ----------
 The name of the StateType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Ganzzahl</translation>
@@ -546,26 +424,12 @@ The name of the StateType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass
         <source>Writable Int (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableIntMinMax, ID: {86a107bc-510a-4d38-bfeb-0a9c2b6d8d87})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableIntMinMax, ID: {86a107bc-510a-4d38-bfeb-0a9c2b6d8d87})
-----------
 The name of the StateType ({86a107bc-510a-4d38-bfeb-0a9c2b6d8d87}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Ganzzahl (min/max)</translation>
     </message>
     <message>
-        <source>Writable Int (min/max) changed</source>
-        <extracomment>The name of the EventType ({86a107bc-510a-4d38-bfeb-0a9c2b6d8d87}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Ganzzahl (min/max) geändert</translation>
-    </message>
-    <message>
-        <source>Writable Int changed</source>
-        <extracomment>The name of the EventType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Ganzzahl geändert</translation>
-    </message>
-    <message>
         <source>Writable String</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableString, ID: {ef511043-bd1a-4a5f-984c-222b7da43f38})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableString, ID: {ef511043-bd1a-4a5f-984c-222b7da43f38})
 ----------
 The name of the StateType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbbare Zeichenkette</translation>
@@ -574,68 +438,33 @@ The name of the StateType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass
         <source>Writable String (selection)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableStringSelection, ID: {209d7afc-6fe9-4fe9-939b-e472ea0ad639})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableStringSelection, ID: {209d7afc-6fe9-4fe9-939b-e472ea0ad639})
-----------
 The name of the StateType ({209d7afc-6fe9-4fe9-939b-e472ea0ad639}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Zeichenkette (Auswahl)</translation>
-    </message>
-    <message>
-        <source>Writable String (selection) changed</source>
-        <extracomment>The name of the EventType ({209d7afc-6fe9-4fe9-939b-e472ea0ad639}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Zeichenkette (Auswahl) geändert</translation>
-    </message>
-    <message>
-        <source>Writable String changed</source>
-        <extracomment>The name of the EventType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Zeichenkette geändert</translation>
     </message>
     <message>
         <source>Writable Time</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTime, ID: {d64c8b3f-ca7d-47f6-b271-867ffd80a4d4})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTime, ID: {d64c8b3f-ca7d-47f6-b271-867ffd80a4d4})
-----------
 The name of the StateType ({d64c8b3f-ca7d-47f6-b271-867ffd80a4d4}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbare Zeit</translation>
-    </message>
-    <message>
-        <source>Writable Time changed</source>
-        <extracomment>The name of the EventType ({d64c8b3f-ca7d-47f6-b271-867ffd80a4d4}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbare Zeit geändert</translation>
     </message>
     <message>
         <source>Writable Timestamp (Int)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTimestampInt, ID: {88b6746a-b009-4df6-8986-d7884ffd94b2})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTimestampInt, ID: {88b6746a-b009-4df6-8986-d7884ffd94b2})
-----------
 The name of the StateType ({88b6746a-b009-4df6-8986-d7884ffd94b2}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbarer Zeitstempel (Int)</translation>
-    </message>
-    <message>
-        <source>Writable Timestamp (Int) changed</source>
-        <extracomment>The name of the EventType ({88b6746a-b009-4df6-8986-d7884ffd94b2}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbarer Zeitstempel (Int) geändert</translation>
     </message>
     <message>
         <source>Writable Timestamp (UInt)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTimestampUInt, ID: {45d0069a-63ac-4265-8170-8152778608ee})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTimestampUInt, ID: {45d0069a-63ac-4265-8170-8152778608ee})
-----------
 The name of the StateType ({45d0069a-63ac-4265-8170-8152778608ee}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbarer Zeitstempel (UInt)</translation>
     </message>
     <message>
-        <source>Writable Timestamp (UInt) changed</source>
-        <extracomment>The name of the EventType ({45d0069a-63ac-4265-8170-8152778608ee}) of ThingClass inputTypeMock</extracomment>
-        <translation>Schreibbarer Zeitstempel (UInt) geändert</translation>
-    </message>
-    <message>
         <source>Writable UInt</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableUInt, ID: {563e9c4c-5198-400a-9f6c-358f4752af58})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableUInt, ID: {563e9c4c-5198-400a-9f6c-358f4752af58})
 ----------
 The name of the StateType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass inputTypeMock</extracomment>
         <translation>Schreibbarer UInt</translation>
@@ -644,42 +473,19 @@ The name of the StateType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass
         <source>Writable UInt (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableUIntMinMax, ID: {79238998-eaab-4d71-b406-5d78f1749751})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableUIntMinMax, ID: {79238998-eaab-4d71-b406-5d78f1749751})
-----------
 The name of the StateType ({79238998-eaab-4d71-b406-5d78f1749751}) of ThingClass inputTypeMock</extracomment>
         <translation>Schriebbarer UInt (min/max)</translation>
-    </message>
-    <message>
-        <source>Writable UInt (min/max) changed</source>
-        <extracomment>The name of the EventType ({79238998-eaab-4d71-b406-5d78f1749751}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable UInt changed</source>
-        <extracomment>The name of the EventType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>allowed values</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: allowedValues, ID: {b463c5ae-4d55-402f-8480-a5cdb485c143})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: allowedValues, ID: {b463c5ae-4d55-402f-8480-a5cdb485c143})
-----------
 The name of the StateType ({b463c5ae-4d55-402f-8480-a5cdb485c143}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: allowedValues, ID: {05f63f9c-f61e-4dcf-ad55-3f13fde2765b})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: allowedValues, ID: {05f63f9c-f61e-4dcf-ad55-3f13fde2765b})
-----------
 The name of the StateType ({05f63f9c-f61e-4dcf-ad55-3f13fde2765b}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished">Mögliche Werte</translation>
-    </message>
-    <message>
-        <source>allowed values changed</source>
-        <extracomment>The name of the EventType ({b463c5ae-4d55-402f-8480-a5cdb485c143}) of ThingClass displayPinMock
-----------
-The name of the EventType ({05f63f9c-f61e-4dcf-ad55-3f13fde2765b}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished">Mögliche Werte geändert</translation>
     </message>
     <message>
         <source>async</source>
@@ -689,60 +495,28 @@ The name of the ParamType (ThingClass: mock, Type: thing, ID: {f2977061-4dd0-4ef
         <translation type="unfinished">asynchron</translation>
     </message>
     <message>
-        <source>battery level</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: batteryLevel, ID: {6c8ab9a6-0164-4795-b829-f4394fe4edc4})
-----------
-The name of the EventType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock
-----------
-The name of the StateType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
-        <translation type="unfinished">Batterieladung</translation>
-    </message>
-    <message>
         <source>battery level critical</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: batteryCritical, ID: {580bc611-1a55-41f3-996f-8d3ccf543db3})
-----------
-The name of the EventType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock
-----------
-The name of the StateType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock</extracomment>
+        <extracomment>The name of the StateType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock</extracomment>
         <translation type="unfinished">Batterieladung kritisch</translation>
     </message>
     <message>
         <source>bool value</source>
         <extracomment>The name of the ParamType (ThingClass: childMock, ActionType: boolValue, ID: {80ba1449-b485-47d4-a067-6bf306e2a568})
 ----------
-The name of the ParamType (ThingClass: childMock, EventType: boolValue, ID: {80ba1449-b485-47d4-a067-6bf306e2a568})
-----------
 The name of the StateType ({80ba1449-b485-47d4-a067-6bf306e2a568}) of ThingClass childMock
 ----------
 The name of the ParamType (ThingClass: parentMock, ActionType: boolValue, ID: {d24ede5f-4064-4898-bb84-cfb533b1fbc0})
-----------
-The name of the ParamType (ThingClass: parentMock, EventType: boolValue, ID: {d24ede5f-4064-4898-bb84-cfb533b1fbc0})
 ----------
 The name of the StateType ({d24ede5f-4064-4898-bb84-cfb533b1fbc0}) of ThingClass parentMock
 ----------
 The name of the ParamType (ThingClass: displayPinMock, ActionType: bool, ID: {7ffe514f-7999-4998-8350-0e73e222a8c4})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: bool, ID: {7ffe514f-7999-4998-8350-0e73e222a8c4})
-----------
 The name of the StateType ({7ffe514f-7999-4998-8350-0e73e222a8c4}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: bool, ID: {e680f7a4-b39e-46da-be41-fa3170fe3768})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: bool, ID: {e680f7a4-b39e-46da-be41-fa3170fe3768})
-----------
 The name of the StateType ({e680f7a4-b39e-46da-be41-fa3170fe3768}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished">Boolscher Wert</translation>
-    </message>
-    <message>
-        <source>bool value changed</source>
-        <extracomment>The name of the EventType ({80ba1449-b485-47d4-a067-6bf306e2a568}) of ThingClass childMock
-----------
-The name of the EventType ({d24ede5f-4064-4898-bb84-cfb533b1fbc0}) of ThingClass parentMock
-----------
-The name of the EventType ({7ffe514f-7999-4998-8350-0e73e222a8c4}) of ThingClass displayPinMock
-----------
-The name of the EventType ({e680f7a4-b39e-46da-be41-fa3170fe3768}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished">Boolscher Wert geändert</translation>
     </message>
     <message>
         <source>broken</source>
@@ -755,23 +529,12 @@ The name of the ParamType (ThingClass: mock, Type: thing, ID: {ae8f8901-f2c1-42a
         <source>color</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: color, ID: {3e161294-8a0d-4384-9676-6959e08cc2fa})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: color, ID: {3e161294-8a0d-4384-9676-6959e08cc2fa})
-----------
 The name of the StateType ({3e161294-8a0d-4384-9676-6959e08cc2fa}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: color, ID: {20dc7c22-c50e-42db-837c-2bbced939f8e})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: color, ID: {20dc7c22-c50e-42db-837c-2bbced939f8e})
-----------
 The name of the StateType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished">Farbe</translation>
-    </message>
-    <message>
-        <source>color changed</source>
-        <extracomment>The name of the EventType ({3e161294-8a0d-4384-9676-6959e08cc2fa}) of ThingClass displayPinMock
-----------
-The name of the EventType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished">Farbe geändert</translation>
     </message>
     <message>
         <source>configParamBool</source>
@@ -787,23 +550,12 @@ The name of the EventType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass
         <source>double value</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: double, ID: {17635624-7c19-4bae-8429-2f7aa5d2f843})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: double, ID: {17635624-7c19-4bae-8429-2f7aa5d2f843})
-----------
 The name of the StateType ({17635624-7c19-4bae-8429-2f7aa5d2f843}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: double, ID: {53cd7c55-49b7-441b-b970-9048f20f0e2c})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: double, ID: {53cd7c55-49b7-441b-b970-9048f20f0e2c})
-----------
 The name of the StateType ({53cd7c55-49b7-441b-b970-9048f20f0e2c}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished">Gleitkommazahl</translation>
-    </message>
-    <message>
-        <source>double value changed</source>
-        <extracomment>The name of the EventType ({17635624-7c19-4bae-8429-2f7aa5d2f843}) of ThingClass displayPinMock
-----------
-The name of the EventType ({53cd7c55-49b7-441b-b970-9048f20f0e2c}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished">Gleitkommazahl geändert</translation>
     </message>
     <message>
         <source>http port</source>
@@ -842,23 +594,12 @@ The name of the ParamType (ThingClass: mock, EventType: event2, ID: {0550e16d-60
         <source>percentage</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: percentage, ID: {527f0687-0b28-4c26-852c-25b8f83e4797})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: percentage, ID: {527f0687-0b28-4c26-852c-25b8f83e4797})
-----------
 The name of the StateType ({527f0687-0b28-4c26-852c-25b8f83e4797}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: percentage, ID: {72981c04-267a-4ba0-a59e-9921d2f3af9c})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: percentage, ID: {72981c04-267a-4ba0-a59e-9921d2f3af9c})
-----------
 The name of the StateType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished">Prozent</translation>
-    </message>
-    <message>
-        <source>percentage changed</source>
-        <extracomment>The name of the EventType ({527f0687-0b28-4c26-852c-25b8f83e4797}) of ThingClass displayPinMock
-----------
-The name of the EventType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished">Prozent geändert</translation>
     </message>
     <message>
         <source>pin</source>
@@ -869,23 +610,14 @@ The name of the EventType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass
         <source>powered</source>
         <extracomment>The name of the ParamType (ThingClass: mock, ActionType: power, ID: {064aed0d-da4c-49d4-b236-60f97e98ff84})
 ----------
-The name of the ParamType (ThingClass: mock, EventType: power, ID: {064aed0d-da4c-49d4-b236-60f97e98ff84})
-----------
 The name of the StateType ({064aed0d-da4c-49d4-b236-60f97e98ff84}) of ThingClass mock</extracomment>
         <translation type="unfinished">Eingeschaltet</translation>
-    </message>
-    <message>
-        <source>powered changed</source>
-        <extracomment>The name of the EventType ({064aed0d-da4c-49d4-b236-60f97e98ff84}) of ThingClass mock</extracomment>
-        <translation type="unfinished">Eingeschaltet geändert</translation>
     </message>
     <message>
         <source>resultCount</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, Type: discovery, ID: {35f6e4ba-28ad-4152-a58d-ec2600667bcf})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, Type: discovery, ID: {c40dbc59-4bba-4871-9b8e-bbd8d5d9193b})
-----------
-The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c-4c3f-8655-76400d0fb6ce})</extracomment>
+The name of the ParamType (ThingClass: pushButtonMock, Type: discovery, ID: {c40dbc59-4bba-4871-9b8e-bbd8d5d9193b})</extracomment>
         <translation type="unfinished">Anzahl Ergebnisse</translation>
     </message>
     <message>
@@ -897,6 +629,247 @@ The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c
         <source>Mock setting</source>
         <extracomment>The name of the ParamType (ThingClass: autoMock, Type: settings, ID: {da0b9106-03cf-4631-87e9-26ade3360182})</extracomment>
         <translation>Mock-Einstellung</translation>
+    </message>
+    <message>
+        <source>Analog Input 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogInput1, ID: {ac56977c-cbba-47c6-a827-5735d8b0aed6})
+----------
+The name of the StateType ({ac56977c-cbba-47c6-a827-5735d8b0aed6}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Input 2</source>
+        <extracomment>The name of the StateType ({8e07e57e-ba4e-42df-81ee-5b72ed074532}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Output 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogOutput1, ID: {70cf053e-4abc-4d88-8e1e-2bd9a62256c7})
+----------
+The name of the StateType ({70cf053e-4abc-4d88-8e1e-2bd9a62256c7}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Output 2</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogOutput2, ID: {e40bcf7d-47b8-41fa-b213-3652a905b376})
+----------
+The name of the StateType ({e40bcf7d-47b8-41fa-b213-3652a905b376}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Available firmware version</source>
+        <extracomment>The name of the StateType ({060d7947-2b70-4a2b-b33b-a3577f71faeb}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Battery level</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: batteryLevel, ID: {6c8ab9a6-0164-4795-b829-f4394fe4edc4})
+----------
+The name of the StateType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button name</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: pressButton, ID: {279e0157-78ea-4bb3-a756-b12fb46cf4fc})
+----------
+The name of the ParamType (ThingClass: mock, EventType: pressed, ID: {5f8adeb2-04f0-4b2e-9dbf-a91966bdcc24})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button pressed</source>
+        <extracomment>The name of the EventType ({f2708625-4b7b-42fd-9a18-3501d89ce599}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <extracomment>The name of the StateType ({9860d105-2bd9-4651-9bc9-13ff4b9039a7}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital Output 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: digitalOutput1, ID: {d6fcdb52-f7c3-423b-b9f5-1e29f164c42e})
+----------
+The name of the StateType ({d6fcdb52-f7c3-423b-b9f5-1e29f164c42e}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital Output 2</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: digitalOutput2, ID: {35de8b68-0cf3-4850-a27d-cf9c4a26921f})
+----------
+The name of the StateType ({35de8b68-0cf3-4850-a27d-cf9c4a26921f}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital input 1</source>
+        <extracomment>The name of the StateType ({07165c12-4d53-45c0-8bf1-34618443b706}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital input 2</source>
+        <extracomment>The name of the StateType ({0a4362ba-a086-4540-84ba-107ef7b99ed8}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dummy int state with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: intWithLimits, ID: {5aa479bd-537a-4716-9852-52f6eec58722})
+----------
+The name of the StateType ({5aa479bd-537a-4716-9852-52f6eec58722}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event 1</source>
+        <extracomment>The name of the EventType ({dad344b4-fff3-4803-b5cb-7cbb65aa5102}) of ThingClass childMock
+----------
+The name of the EventType ({61ebadc0-47ea-4800-8c45-ee5222cddb4b}) of ThingClass parentMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Firmware version</source>
+        <extracomment>The name of the StateType ({9f2e1e5d-3f1f-4794-aca3-4e05b7a48842}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic IO pins</source>
+        <extracomment>The name of the ThingClass ({7cbd729a-465b-4ccb-b59c-5733039dbbed})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic Light (Mock)</source>
+        <extracomment>The name of the ThingClass ({98ab137e-757e-43f8-9d9b-5d50d990242a})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic Temperature Sensor (Mock)</source>
+        <extracomment>The name of the ThingClass ({f8917e12-c9cb-4ea1-a06e-1ce6db2194f3})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, ActionType: input, ID: {fd341f72-6d9a-4812-9f66-47197c48a935})
+----------
+The name of the StateType ({fd341f72-6d9a-4812-9f66-47197c48a935}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum temperature</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, Type: settings, ID: {7077c56f-c35b-4252-8c15-8fb549be04ce})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum value for int with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: settings, ID: {984e7ae0-6de7-447e-bc4d-5afde8a00f27})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum temperature</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, Type: settings, ID: {803cddbf-94c7-4f35-bc7a-18698b03b942})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum value for int with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: settings, ID: {9c34c881-e825-4f27-bb5c-db868bc60fb1})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Param with default value</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: withParams, ID: {d1e428ae-eb8c-45aa-b1b0-e3d7de659c3a})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoLightMock, ActionType: power, ID: {d1917b3d-1530-4cf9-90f7-263ee88e714b})
+----------
+The name of the StateType ({d1917b3d-1530-4cf9-90f7-263ee88e714b}) of ThingClass virtualIoLightMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press button</source>
+        <extracomment>The name of the ActionType ({592dfded-0144-4947-bd02-ca84c2124f39}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Result count</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c-4c3f-8655-76400d0fb6ce})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Digital Output 1</source>
+        <extracomment>The name of the ActionType ({d6fcdb52-f7c3-423b-b9f5-1e29f164c42e}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Digital Output 2</source>
+        <extracomment>The name of the ActionType ({35de8b68-0cf3-4850-a27d-cf9c4a26921f}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Output Input 1</source>
+        <extracomment>The name of the ActionType ({70cf053e-4abc-4d88-8e1e-2bd9a62256c7}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Output Input 2</source>
+        <extracomment>The name of the ActionType ({e40bcf7d-47b8-41fa-b213-3652a905b376}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set analog input 1</source>
+        <extracomment>The name of the ActionType ({ac56977c-cbba-47c6-a827-5735d8b0aed6}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set battery level</source>
+        <extracomment>The name of the ActionType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set dummy int state with limits</source>
+        <extracomment>The name of the ActionType ({5aa479bd-537a-4716-9852-52f6eec58722}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set input</source>
+        <extracomment>The name of the ActionType ({fd341f72-6d9a-4812-9f66-47197c48a935}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set power</source>
+        <extracomment>The name of the ActionType ({d1917b3d-1530-4cf9-90f7-263ee88e714b}) of ThingClass virtualIoLightMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set signal strength</source>
+        <extracomment>The name of the ActionType ({2a0213bf-4af3-4384-904e-3376348a597e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set update status</source>
+        <extracomment>The name of the ActionType ({ebc41327-53d5-40c2-8e7b-1164a8ff359e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Signal strength</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: signalStrength, ID: {2a0213bf-4af3-4384-904e-3376348a597e})
+----------
+The name of the StateType ({2a0213bf-4af3-4384-904e-3376348a597e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <extracomment>The name of the StateType ({db9cc518-1012-47e2-8212-6e616fed07a6}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update firmware</source>
+        <extracomment>The name of the ActionType ({f2b847dd-ab40-4278-940b-3615f1d7dfd3}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update status</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: updateStatus, ID: {ebc41327-53d5-40c2-8e7b-1164a8ff359e})
+----------
+The name of the StateType ({ebc41327-53d5-40c2-8e7b-1164a8ff359e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/plugins/mock/translations/727a4a9a-c187-446f-aadf-f1b2220607d1-en_US.ts
+++ b/plugins/mock/translations/727a4a9a-c187-446f-aadf-f1b2220607d1-en_US.ts
@@ -53,86 +53,36 @@
     </message>
     <message>
         <source>Bool</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: bool, ID: {3bad3a09-5826-4ed7-a832-10e3e2ee2a7d})
-----------
-The name of the StateType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Bool changed</source>
-        <extracomment>The name of the EventType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({3bad3a09-5826-4ed7-a832-10e3e2ee2a7d}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: color, ID: {4507d5c6-b692-4bd6-87f2-00364bc0cb4d})
-----------
-The name of the StateType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Color changed</source>
-        <extracomment>The name of the EventType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({4507d5c6-b692-4bd6-87f2-00364bc0cb4d}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Double</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: double, ID: {f7d2063d-959e-46ac-8568-8b99722d3b22})
-----------
-The name of the StateType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Double changed</source>
-        <extracomment>The name of the EventType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({f7d2063d-959e-46ac-8568-8b99722d3b22}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dummy bool state</source>
-        <extracomment>The name of the ParamType (ThingClass: autoMock, EventType: boolValue, ID: {978b0ba5-d008-41bd-b63d-a3bd23cb6469})
-----------
-The name of the StateType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
-----------
-The name of the ParamType (ThingClass: mock, EventType: bool, ID: {9dd6a97c-dfd1-43dc-acbd-367932742310})
+        <extracomment>The name of the StateType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
 ----------
 The name of the StateType ({9dd6a97c-dfd1-43dc-acbd-367932742310}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Dummy bool state changed</source>
-        <extracomment>The name of the EventType ({978b0ba5-d008-41bd-b63d-a3bd23cb6469}) of ThingClass autoMock
-----------
-The name of the EventType ({9dd6a97c-dfd1-43dc-acbd-367932742310}) of ThingClass mock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dummy double state</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: double, ID: {7cac53ee-7048-4dc9-b000-7b585390f34c})
-----------
-The name of the StateType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dummy double state changed</source>
-        <extracomment>The name of the EventType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
+        <extracomment>The name of the StateType ({7cac53ee-7048-4dc9-b000-7b585390f34c}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dummy int state</source>
-        <extracomment>The name of the ParamType (ThingClass: autoMock, EventType: int, ID: {74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c})
-----------
-The name of the StateType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
-----------
-The name of the ParamType (ThingClass: mock, EventType: int, ID: {80baec19-54de-4948-ac46-31eabfaceb83})
+        <extracomment>The name of the StateType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
 ----------
 The name of the StateType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass mock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dummy int state changed</source>
-        <extracomment>The name of the EventType ({74b24296-ba0b-4fbd-87f3-1b09a8bc3e8c}) of ThingClass autoMock
-----------
-The name of the EventType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -147,14 +97,7 @@ The name of the EventType ({80baec19-54de-4948-ac46-31eabfaceb83}) of ThingClass
     </message>
     <message>
         <source>Int</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: int, ID: {d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb})
-----------
-The name of the StateType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Int changed</source>
-        <extracomment>The name of the EventType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({d0fc56ae-5791-4e91-b76c-dadfbc7e7dbb}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -397,14 +340,7 @@ The name of the ActionType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClas
     </message>
     <message>
         <source>String</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: string, ID: {27f69ca9-a321-40ff-bfee-4b0272a671b4})
-----------
-The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>String changed</source>
-        <extracomment>The name of the EventType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -419,14 +355,7 @@ The name of the StateType ({27f69ca9-a321-40ff-bfee-4b0272a671b4}) of ThingClass
     </message>
     <message>
         <source>Time</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: time, ID: {8250c71e-59bc-41ab-b576-99fcfc34e8d1})
-----------
-The name of the StateType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Time changed</source>
-        <extracomment>The name of the EventType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({8250c71e-59bc-41ab-b576-99fcfc34e8d1}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -438,38 +367,17 @@ The name of the ActionType ({54646e7c-bc54-4895-81a2-590d72d120f9}) of ThingClas
     </message>
     <message>
         <source>Timestamp (Int)</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: timestampInt, ID: {2c91b5ef-c2d1-4367-bc65-5a13abf69641})
-----------
-The name of the StateType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Timestamp (Int) changed</source>
-        <extracomment>The name of the EventType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({2c91b5ef-c2d1-4367-bc65-5a13abf69641}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Timestamp (UInt)</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: timestampUInt, ID: {6c9a96e8-0d48-4f42-8967-848358fd7f79})
-----------
-The name of the StateType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Timestamp (UInt) changed</source>
-        <extracomment>The name of the EventType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({6c9a96e8-0d48-4f42-8967-848358fd7f79}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UInt</source>
-        <extracomment>The name of the ParamType (ThingClass: inputTypeMock, EventType: uint, ID: {19e74fcc-bfd5-491f-8eb6-af128e8f1162})
-----------
-The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>UInt changed</source>
-        <extracomment>The name of the EventType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
+        <extracomment>The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -481,35 +389,19 @@ The name of the StateType ({19e74fcc-bfd5-491f-8eb6-af128e8f1162}) of ThingClass
         <source>Writable Bool</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableBool, ID: {a7c11774-f31f-4d64-99d1-e0ae5fb35a5c})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableBool, ID: {a7c11774-f31f-4d64-99d1-e0ae5fb35a5c})
-----------
 The name of the StateType ({a7c11774-f31f-4d64-99d1-e0ae5fb35a5c}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Bool changed</source>
-        <extracomment>The name of the EventType ({a7c11774-f31f-4d64-99d1-e0ae5fb35a5c}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Color</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableColor, ID: {455f4f68-3cb0-4e8a-a707-62e4a2a8035c})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableColor, ID: {455f4f68-3cb0-4e8a-a707-62e4a2a8035c})
-----------
 The name of the StateType ({455f4f68-3cb0-4e8a-a707-62e4a2a8035c}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Color changed</source>
-        <extracomment>The name of the EventType ({455f4f68-3cb0-4e8a-a707-62e4a2a8035c}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Double</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableDouble, ID: {8e2eb91b-d60b-4461-9a50-d7b8ad263170})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableDouble, ID: {8e2eb91b-d60b-4461-9a50-d7b8ad263170})
 ----------
 The name of the StateType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
@@ -518,26 +410,12 @@ The name of the StateType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass
         <source>Writable Double (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableDoubleMinMax, ID: {00d3425e-1da6-4748-8906-4555ceefb136})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableDoubleMinMax, ID: {00d3425e-1da6-4748-8906-4555ceefb136})
-----------
 The name of the StateType ({00d3425e-1da6-4748-8906-4555ceefb136}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Double (min/max) changed</source>
-        <extracomment>The name of the EventType ({00d3425e-1da6-4748-8906-4555ceefb136}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Double changed</source>
-        <extracomment>The name of the EventType ({8e2eb91b-d60b-4461-9a50-d7b8ad263170}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Int</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableInt, ID: {857a8422-983c-47d6-a15f-d8450b3162f7})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableInt, ID: {857a8422-983c-47d6-a15f-d8450b3162f7})
 ----------
 The name of the StateType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
@@ -546,26 +424,12 @@ The name of the StateType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass
         <source>Writable Int (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableIntMinMax, ID: {86a107bc-510a-4d38-bfeb-0a9c2b6d8d87})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableIntMinMax, ID: {86a107bc-510a-4d38-bfeb-0a9c2b6d8d87})
-----------
 The name of the StateType ({86a107bc-510a-4d38-bfeb-0a9c2b6d8d87}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Int (min/max) changed</source>
-        <extracomment>The name of the EventType ({86a107bc-510a-4d38-bfeb-0a9c2b6d8d87}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Int changed</source>
-        <extracomment>The name of the EventType ({857a8422-983c-47d6-a15f-d8450b3162f7}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable String</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableString, ID: {ef511043-bd1a-4a5f-984c-222b7da43f38})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableString, ID: {ef511043-bd1a-4a5f-984c-222b7da43f38})
 ----------
 The name of the StateType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
@@ -574,68 +438,33 @@ The name of the StateType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass
         <source>Writable String (selection)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableStringSelection, ID: {209d7afc-6fe9-4fe9-939b-e472ea0ad639})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableStringSelection, ID: {209d7afc-6fe9-4fe9-939b-e472ea0ad639})
-----------
 The name of the StateType ({209d7afc-6fe9-4fe9-939b-e472ea0ad639}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable String (selection) changed</source>
-        <extracomment>The name of the EventType ({209d7afc-6fe9-4fe9-939b-e472ea0ad639}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable String changed</source>
-        <extracomment>The name of the EventType ({ef511043-bd1a-4a5f-984c-222b7da43f38}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Time</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTime, ID: {d64c8b3f-ca7d-47f6-b271-867ffd80a4d4})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTime, ID: {d64c8b3f-ca7d-47f6-b271-867ffd80a4d4})
-----------
 The name of the StateType ({d64c8b3f-ca7d-47f6-b271-867ffd80a4d4}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Time changed</source>
-        <extracomment>The name of the EventType ({d64c8b3f-ca7d-47f6-b271-867ffd80a4d4}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Timestamp (Int)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTimestampInt, ID: {88b6746a-b009-4df6-8986-d7884ffd94b2})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTimestampInt, ID: {88b6746a-b009-4df6-8986-d7884ffd94b2})
-----------
 The name of the StateType ({88b6746a-b009-4df6-8986-d7884ffd94b2}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Timestamp (Int) changed</source>
-        <extracomment>The name of the EventType ({88b6746a-b009-4df6-8986-d7884ffd94b2}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable Timestamp (UInt)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableTimestampUInt, ID: {45d0069a-63ac-4265-8170-8152778608ee})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableTimestampUInt, ID: {45d0069a-63ac-4265-8170-8152778608ee})
-----------
 The name of the StateType ({45d0069a-63ac-4265-8170-8152778608ee}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable Timestamp (UInt) changed</source>
-        <extracomment>The name of the EventType ({45d0069a-63ac-4265-8170-8152778608ee}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Writable UInt</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableUInt, ID: {563e9c4c-5198-400a-9f6c-358f4752af58})
-----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableUInt, ID: {563e9c4c-5198-400a-9f6c-358f4752af58})
 ----------
 The name of the StateType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
@@ -644,41 +473,18 @@ The name of the StateType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass
         <source>Writable UInt (min/max)</source>
         <extracomment>The name of the ParamType (ThingClass: inputTypeMock, ActionType: writableUIntMinMax, ID: {79238998-eaab-4d71-b406-5d78f1749751})
 ----------
-The name of the ParamType (ThingClass: inputTypeMock, EventType: writableUIntMinMax, ID: {79238998-eaab-4d71-b406-5d78f1749751})
-----------
 The name of the StateType ({79238998-eaab-4d71-b406-5d78f1749751}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable UInt (min/max) changed</source>
-        <extracomment>The name of the EventType ({79238998-eaab-4d71-b406-5d78f1749751}) of ThingClass inputTypeMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Writable UInt changed</source>
-        <extracomment>The name of the EventType ({563e9c4c-5198-400a-9f6c-358f4752af58}) of ThingClass inputTypeMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>allowed values</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: allowedValues, ID: {b463c5ae-4d55-402f-8480-a5cdb485c143})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: allowedValues, ID: {b463c5ae-4d55-402f-8480-a5cdb485c143})
-----------
 The name of the StateType ({b463c5ae-4d55-402f-8480-a5cdb485c143}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: allowedValues, ID: {05f63f9c-f61e-4dcf-ad55-3f13fde2765b})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: allowedValues, ID: {05f63f9c-f61e-4dcf-ad55-3f13fde2765b})
-----------
 The name of the StateType ({05f63f9c-f61e-4dcf-ad55-3f13fde2765b}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>allowed values changed</source>
-        <extracomment>The name of the EventType ({b463c5ae-4d55-402f-8480-a5cdb485c143}) of ThingClass displayPinMock
-----------
-The name of the EventType ({05f63f9c-f61e-4dcf-ad55-3f13fde2765b}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -689,59 +495,27 @@ The name of the ParamType (ThingClass: mock, Type: thing, ID: {f2977061-4dd0-4ef
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>battery level</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: batteryLevel, ID: {6c8ab9a6-0164-4795-b829-f4394fe4edc4})
-----------
-The name of the EventType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock
-----------
-The name of the StateType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>battery level critical</source>
-        <extracomment>The name of the ParamType (ThingClass: mock, EventType: batteryCritical, ID: {580bc611-1a55-41f3-996f-8d3ccf543db3})
-----------
-The name of the EventType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock
-----------
-The name of the StateType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock</extracomment>
+        <extracomment>The name of the StateType ({580bc611-1a55-41f3-996f-8d3ccf543db3}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>bool value</source>
         <extracomment>The name of the ParamType (ThingClass: childMock, ActionType: boolValue, ID: {80ba1449-b485-47d4-a067-6bf306e2a568})
 ----------
-The name of the ParamType (ThingClass: childMock, EventType: boolValue, ID: {80ba1449-b485-47d4-a067-6bf306e2a568})
-----------
 The name of the StateType ({80ba1449-b485-47d4-a067-6bf306e2a568}) of ThingClass childMock
 ----------
 The name of the ParamType (ThingClass: parentMock, ActionType: boolValue, ID: {d24ede5f-4064-4898-bb84-cfb533b1fbc0})
-----------
-The name of the ParamType (ThingClass: parentMock, EventType: boolValue, ID: {d24ede5f-4064-4898-bb84-cfb533b1fbc0})
 ----------
 The name of the StateType ({d24ede5f-4064-4898-bb84-cfb533b1fbc0}) of ThingClass parentMock
 ----------
 The name of the ParamType (ThingClass: displayPinMock, ActionType: bool, ID: {7ffe514f-7999-4998-8350-0e73e222a8c4})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: bool, ID: {7ffe514f-7999-4998-8350-0e73e222a8c4})
-----------
 The name of the StateType ({7ffe514f-7999-4998-8350-0e73e222a8c4}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: bool, ID: {e680f7a4-b39e-46da-be41-fa3170fe3768})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: bool, ID: {e680f7a4-b39e-46da-be41-fa3170fe3768})
-----------
 The name of the StateType ({e680f7a4-b39e-46da-be41-fa3170fe3768}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>bool value changed</source>
-        <extracomment>The name of the EventType ({80ba1449-b485-47d4-a067-6bf306e2a568}) of ThingClass childMock
-----------
-The name of the EventType ({d24ede5f-4064-4898-bb84-cfb533b1fbc0}) of ThingClass parentMock
-----------
-The name of the EventType ({7ffe514f-7999-4998-8350-0e73e222a8c4}) of ThingClass displayPinMock
-----------
-The name of the EventType ({e680f7a4-b39e-46da-be41-fa3170fe3768}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -755,22 +529,11 @@ The name of the ParamType (ThingClass: mock, Type: thing, ID: {ae8f8901-f2c1-42a
         <source>color</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: color, ID: {3e161294-8a0d-4384-9676-6959e08cc2fa})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: color, ID: {3e161294-8a0d-4384-9676-6959e08cc2fa})
-----------
 The name of the StateType ({3e161294-8a0d-4384-9676-6959e08cc2fa}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: color, ID: {20dc7c22-c50e-42db-837c-2bbced939f8e})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: color, ID: {20dc7c22-c50e-42db-837c-2bbced939f8e})
-----------
 The name of the StateType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>color changed</source>
-        <extracomment>The name of the EventType ({3e161294-8a0d-4384-9676-6959e08cc2fa}) of ThingClass displayPinMock
-----------
-The name of the EventType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -787,22 +550,11 @@ The name of the EventType ({20dc7c22-c50e-42db-837c-2bbced939f8e}) of ThingClass
         <source>double value</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: double, ID: {17635624-7c19-4bae-8429-2f7aa5d2f843})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: double, ID: {17635624-7c19-4bae-8429-2f7aa5d2f843})
-----------
 The name of the StateType ({17635624-7c19-4bae-8429-2f7aa5d2f843}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: double, ID: {53cd7c55-49b7-441b-b970-9048f20f0e2c})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: double, ID: {53cd7c55-49b7-441b-b970-9048f20f0e2c})
-----------
 The name of the StateType ({53cd7c55-49b7-441b-b970-9048f20f0e2c}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>double value changed</source>
-        <extracomment>The name of the EventType ({17635624-7c19-4bae-8429-2f7aa5d2f843}) of ThingClass displayPinMock
-----------
-The name of the EventType ({53cd7c55-49b7-441b-b970-9048f20f0e2c}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -842,22 +594,11 @@ The name of the ParamType (ThingClass: mock, EventType: event2, ID: {0550e16d-60
         <source>percentage</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, ActionType: percentage, ID: {527f0687-0b28-4c26-852c-25b8f83e4797})
 ----------
-The name of the ParamType (ThingClass: displayPinMock, EventType: percentage, ID: {527f0687-0b28-4c26-852c-25b8f83e4797})
-----------
 The name of the StateType ({527f0687-0b28-4c26-852c-25b8f83e4797}) of ThingClass displayPinMock
 ----------
 The name of the ParamType (ThingClass: pushButtonMock, ActionType: percentage, ID: {72981c04-267a-4ba0-a59e-9921d2f3af9c})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, EventType: percentage, ID: {72981c04-267a-4ba0-a59e-9921d2f3af9c})
-----------
 The name of the StateType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass pushButtonMock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>percentage changed</source>
-        <extracomment>The name of the EventType ({527f0687-0b28-4c26-852c-25b8f83e4797}) of ThingClass displayPinMock
-----------
-The name of the EventType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass pushButtonMock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -869,23 +610,14 @@ The name of the EventType ({72981c04-267a-4ba0-a59e-9921d2f3af9c}) of ThingClass
         <source>powered</source>
         <extracomment>The name of the ParamType (ThingClass: mock, ActionType: power, ID: {064aed0d-da4c-49d4-b236-60f97e98ff84})
 ----------
-The name of the ParamType (ThingClass: mock, EventType: power, ID: {064aed0d-da4c-49d4-b236-60f97e98ff84})
-----------
 The name of the StateType ({064aed0d-da4c-49d4-b236-60f97e98ff84}) of ThingClass mock</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>powered changed</source>
-        <extracomment>The name of the EventType ({064aed0d-da4c-49d4-b236-60f97e98ff84}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <source>resultCount</source>
         <extracomment>The name of the ParamType (ThingClass: displayPinMock, Type: discovery, ID: {35f6e4ba-28ad-4152-a58d-ec2600667bcf})
 ----------
-The name of the ParamType (ThingClass: pushButtonMock, Type: discovery, ID: {c40dbc59-4bba-4871-9b8e-bbd8d5d9193b})
-----------
-The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c-4c3f-8655-76400d0fb6ce})</extracomment>
+The name of the ParamType (ThingClass: pushButtonMock, Type: discovery, ID: {c40dbc59-4bba-4871-9b8e-bbd8d5d9193b})</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -896,6 +628,247 @@ The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c
     <message>
         <source>Mock setting</source>
         <extracomment>The name of the ParamType (ThingClass: autoMock, Type: settings, ID: {da0b9106-03cf-4631-87e9-26ade3360182})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Input 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogInput1, ID: {ac56977c-cbba-47c6-a827-5735d8b0aed6})
+----------
+The name of the StateType ({ac56977c-cbba-47c6-a827-5735d8b0aed6}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Input 2</source>
+        <extracomment>The name of the StateType ({8e07e57e-ba4e-42df-81ee-5b72ed074532}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Output 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogOutput1, ID: {70cf053e-4abc-4d88-8e1e-2bd9a62256c7})
+----------
+The name of the StateType ({70cf053e-4abc-4d88-8e1e-2bd9a62256c7}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Analog Output 2</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: analogOutput2, ID: {e40bcf7d-47b8-41fa-b213-3652a905b376})
+----------
+The name of the StateType ({e40bcf7d-47b8-41fa-b213-3652a905b376}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Available firmware version</source>
+        <extracomment>The name of the StateType ({060d7947-2b70-4a2b-b33b-a3577f71faeb}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Battery level</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: batteryLevel, ID: {6c8ab9a6-0164-4795-b829-f4394fe4edc4})
+----------
+The name of the StateType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button name</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: pressButton, ID: {279e0157-78ea-4bb3-a756-b12fb46cf4fc})
+----------
+The name of the ParamType (ThingClass: mock, EventType: pressed, ID: {5f8adeb2-04f0-4b2e-9dbf-a91966bdcc24})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Button pressed</source>
+        <extracomment>The name of the EventType ({f2708625-4b7b-42fd-9a18-3501d89ce599}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connected</source>
+        <extracomment>The name of the StateType ({9860d105-2bd9-4651-9bc9-13ff4b9039a7}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital Output 1</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: digitalOutput1, ID: {d6fcdb52-f7c3-423b-b9f5-1e29f164c42e})
+----------
+The name of the StateType ({d6fcdb52-f7c3-423b-b9f5-1e29f164c42e}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital Output 2</source>
+        <extracomment>The name of the ParamType (ThingClass: genericIoMock, ActionType: digitalOutput2, ID: {35de8b68-0cf3-4850-a27d-cf9c4a26921f})
+----------
+The name of the StateType ({35de8b68-0cf3-4850-a27d-cf9c4a26921f}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital input 1</source>
+        <extracomment>The name of the StateType ({07165c12-4d53-45c0-8bf1-34618443b706}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Digital input 2</source>
+        <extracomment>The name of the StateType ({0a4362ba-a086-4540-84ba-107ef7b99ed8}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dummy int state with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: intWithLimits, ID: {5aa479bd-537a-4716-9852-52f6eec58722})
+----------
+The name of the StateType ({5aa479bd-537a-4716-9852-52f6eec58722}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Event 1</source>
+        <extracomment>The name of the EventType ({dad344b4-fff3-4803-b5cb-7cbb65aa5102}) of ThingClass childMock
+----------
+The name of the EventType ({61ebadc0-47ea-4800-8c45-ee5222cddb4b}) of ThingClass parentMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Firmware version</source>
+        <extracomment>The name of the StateType ({9f2e1e5d-3f1f-4794-aca3-4e05b7a48842}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic IO pins</source>
+        <extracomment>The name of the ThingClass ({7cbd729a-465b-4ccb-b59c-5733039dbbed})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic Light (Mock)</source>
+        <extracomment>The name of the ThingClass ({98ab137e-757e-43f8-9d9b-5d50d990242a})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Generic Temperature Sensor (Mock)</source>
+        <extracomment>The name of the ThingClass ({f8917e12-c9cb-4ea1-a06e-1ce6db2194f3})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, ActionType: input, ID: {fd341f72-6d9a-4812-9f66-47197c48a935})
+----------
+The name of the StateType ({fd341f72-6d9a-4812-9f66-47197c48a935}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum temperature</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, Type: settings, ID: {7077c56f-c35b-4252-8c15-8fb549be04ce})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Maximum value for int with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: settings, ID: {984e7ae0-6de7-447e-bc4d-5afde8a00f27})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum temperature</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoTemperatureSensorMock, Type: settings, ID: {803cddbf-94c7-4f35-bc7a-18698b03b942})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Minimum value for int with limits</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: settings, ID: {9c34c881-e825-4f27-bb5c-db868bc60fb1})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Param with default value</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: withParams, ID: {d1e428ae-eb8c-45aa-b1b0-e3d7de659c3a})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <extracomment>The name of the ParamType (ThingClass: virtualIoLightMock, ActionType: power, ID: {d1917b3d-1530-4cf9-90f7-263ee88e714b})
+----------
+The name of the StateType ({d1917b3d-1530-4cf9-90f7-263ee88e714b}) of ThingClass virtualIoLightMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Press button</source>
+        <extracomment>The name of the ActionType ({592dfded-0144-4947-bd02-ca84c2124f39}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Result count</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, Type: discovery, ID: {d222adb4-2f9c-4c3f-8655-76400d0fb6ce})</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Digital Output 1</source>
+        <extracomment>The name of the ActionType ({d6fcdb52-f7c3-423b-b9f5-1e29f164c42e}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Digital Output 2</source>
+        <extracomment>The name of the ActionType ({35de8b68-0cf3-4850-a27d-cf9c4a26921f}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Output Input 1</source>
+        <extracomment>The name of the ActionType ({70cf053e-4abc-4d88-8e1e-2bd9a62256c7}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set Output Input 2</source>
+        <extracomment>The name of the ActionType ({e40bcf7d-47b8-41fa-b213-3652a905b376}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set analog input 1</source>
+        <extracomment>The name of the ActionType ({ac56977c-cbba-47c6-a827-5735d8b0aed6}) of ThingClass genericIoMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set battery level</source>
+        <extracomment>The name of the ActionType ({6c8ab9a6-0164-4795-b829-f4394fe4edc4}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set dummy int state with limits</source>
+        <extracomment>The name of the ActionType ({5aa479bd-537a-4716-9852-52f6eec58722}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set input</source>
+        <extracomment>The name of the ActionType ({fd341f72-6d9a-4812-9f66-47197c48a935}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set power</source>
+        <extracomment>The name of the ActionType ({d1917b3d-1530-4cf9-90f7-263ee88e714b}) of ThingClass virtualIoLightMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set signal strength</source>
+        <extracomment>The name of the ActionType ({2a0213bf-4af3-4384-904e-3376348a597e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set update status</source>
+        <extracomment>The name of the ActionType ({ebc41327-53d5-40c2-8e7b-1164a8ff359e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Signal strength</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: signalStrength, ID: {2a0213bf-4af3-4384-904e-3376348a597e})
+----------
+The name of the StateType ({2a0213bf-4af3-4384-904e-3376348a597e}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Temperature</source>
+        <extracomment>The name of the StateType ({db9cc518-1012-47e2-8212-6e616fed07a6}) of ThingClass virtualIoTemperatureSensorMock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update firmware</source>
+        <extracomment>The name of the ActionType ({f2b847dd-ab40-4278-940b-3615f1d7dfd3}) of ThingClass mock</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Update status</source>
+        <extracomment>The name of the ParamType (ThingClass: mock, ActionType: updateStatus, ID: {ebc41327-53d5-40c2-8e7b-1164a8ff359e})
+----------
+The name of the StateType ({ebc41327-53d5-40c2-8e7b-1164a8ff359e}) of ThingClass mock</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/nymead-cs.ts
+++ b/translations/nymead-cs.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Cloud notifikace</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>ID uživatele</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Zařízení</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Text zprávy</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Poslat notifikaci</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>připojeno</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Připojeno změněno</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea je otevřený (open source) server IoT (Internet of Things), který umož�
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Spusťte nymead v popředí, ne jako démona.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Specifikujte log file k zapisování, pokud tato možnost není specifikována, logs budou tištěny ke standardnímu výstupu.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Pokud je specifikováno, všechna rozhraní D-bus budou napojena k sekční sběrnici místo k systémové sběrnici.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Ladění nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>nymea rozhraní k ladění</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Vítejte u rozhraní k ladění.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Toto rozhraní k ladění bylo vytvořeno k poskytnutí snadné možnosti získání užitečných informací o fungování serveru nymea.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Uvědomte si, že toto rozhraní k ladění je bezpečnostním rizikem a mohlo by nabídnout přístup k citlivým údajům.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Informace o serveru</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Uživatel</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Kompilováno s verzí Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Verze Qt runtime</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Příkaz</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Název snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Verze snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Adresář snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Aplikační data snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Uživatelská data snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Společná data snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Název serveru</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Verze serveru</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>Verze JSON-RPC</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Jazyk</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Zóna času</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Server UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Nastavení cesta</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Překlady cesta</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Databáze Log</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Downloads (ke stažení)</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Logs</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Download (ke stažení)</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Logs systému</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>nastavení nymead</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Spuštěno pod obecnou veřejnou licencí GNU GENERAL PUBLIC LICENSE verze 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Spuštěno pod obecnou veřejnou licencí GNU GENERAL PUBLIC LICENSE verze 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Chyba  %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Nemohl být nalezen soubor &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Nemohl být otevřen soubor &quot;%1&quot;.</translation>

--- a/translations/nymead-da.ts
+++ b/translations/nymead-da.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Cloud-meddelelser</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Bruger-id</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Enhed</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Meddelelsestekst</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Send meddelelse</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>forbundet</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Forbindelse ændret</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea er en open source IoT-server (&quot;Internet of Things&quot;), som giver m
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Kør nymead i forgrunden, ikke som daemon.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Specificér en logfil, der skal skrives til. Hvis denne mulighed ikke er specificeret, udskrives logger til standard-output.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Hvis det specificeret, vil alle D-Bus grænseflader være bundet til session-bussen i stedet for system-bussen.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Debug nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>nymea debug-grænseflade</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Velkommen til debug-grænsefladen.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Denne debug-grænseflade er udviklet til at gøre det nemt at få praktiske oplysninger nymea-serveren, der er i drift.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Vær opmærksom på, at denne debug-grænseflade er en sikkerhedsrisiko og kan give adgang til følsomme data.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Server-information</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Bruger</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Kompileret med Qt-version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Qt runtime-version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Command</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-navn</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-mappe</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-applikationsdata</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-brugerdata</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-fællesdata</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Servernavn</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Server-version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>JSON-RPC-version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Sprog</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Tidszone</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Server-UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Indstillingssti</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Oversættelsessti</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Log-database</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Logger</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>System-logger</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>nymead-indstillinger</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Udgivet i henhold til GNU GENERAL PUBLIC LICENSE Version 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Udgivet i henhold til GNU GENERAL PUBLIC LICENSE Version 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Fejl %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Kunne ikke finde filen &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Kunne ikke åbne filen &quot;%1&quot;.</translation>

--- a/translations/nymead-de.ts
+++ b/translations/nymead-de.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Cloud Benachrichtigung</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Benutzer ID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Gerät</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Nachrichtentext</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Sende Benachrichtigung</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>Verbunden</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Verbunden geändert</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation>Das Plugin für dieses \&quot;Thing\&quot; konnte nicht geladen werden.</translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,72 +67,80 @@ nymea ist ein Open-Source-IoT (Internet der Dinge) Server, der es ermöglicht, v
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Führe Nymead im Vordergrund aus, nicht als Daemon.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
-        <translation>Debug -Kategorien zum Aktivieren. Präfix mit &quot;No&quot; zum Deaktivieren. Suffix mit &quot;Warnings&quot;, um Warnungen zu bekommen.
-Beispiele:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Kategorien sind:</translation>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
+        <translation>Deaktiviert das Schreiben von debug, info und warning Kategorien.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
-        <translation>Aktiviert alle Debug-Kategorien außer *Graffic- und *Debug-Kategorien. Einzelne Debug-Kategorien können mit dem Parameter -d wieder deaktiviert werden.</translation>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
+        <translation>Aktiviert alle info und debug Kategorien ausgenommen *Traffic und *Debug Kategorien.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Geben Sie eine Log-datei an, in die geschrieben werden soll. Wenn diese Option nicht angegeben wird, werden Protokolle auf die Standardausgabe gedruckt.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation>Die Log-Ausgabe ist normalerweise eingefärbt. Diese Option ermöglicht das Ausschalten der Farbe.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Falls angegeben, werden alle D-Bus Schnittstellen auf dem Sitzungs-Bus anstatt auf dem System-Bus zur Verfügung gestellt.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation>Zu aktiviernde Debug-Kategorien. Der Präfix &quot;No&quot; deaktivert die entsprechende Kategorie. Der Suffix &quot;Info&quot; oder &quot;Warning&quot; wählt die entsprechende info oder warning Kategorie. Das Aktivieren einer debug Kategorie aktiviert auch die entsprechende info und warning Kategorien.
+Beispiele:
+-d ThingManager
+-d NoApplicationInfo
+
+</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation>Zusätzliche Schnittstellen um auf Verbindungen zu hören, in nymea URI Format (z.B. nymeas://127.0.0.2:7777). Achtung: Schnittstellen die auf diese Weise aktiviert werden, benötigen keine Authentifizierung und sind nur zu Testzwecken vorgesehen.</translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Debug nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>nymea Debug-Schnittstelle</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation>Imformationen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -145,190 +148,161 @@ The network section of the debug interface</extracomment>
         <translation>Netzwerk</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Willkommen bei der Debug-Schnittstelle.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Diese Debug-Oberfläche wurde entwickelt, um eine einfache Möglichkeit zu geben, hilfreiche Informationen über den laufenden nymea-Server zu erhalten.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Beachten Sie, dass diese Debug-Schnittstelle ein Sicherheitsrisiko darstellt und Zugriff auf sensible Daten bieten könnte.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Server Information</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Benutzer</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Kompiliert mit Qt-Version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Qt Runtime-Version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Kommando</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Snap Name</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Snap Version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Snap Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap Anwendungsdaten</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap Benutzerdaten</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap gemeinsame Daten</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Servername</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Server Version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>JSON-RPC Version</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Sprache</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Zeitzone</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Server UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Einstellungen Pfad</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Übersetzungspfad</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation>Bericht generieren</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation>Wenn Sie einem Entwickler alle Debug-Informationen zur Verfügung stellen möchten, können Sie eine Berichtsdatei erstellen, die alle Informationen enthält, die zum Reproduzieren eines Systems erforderlich sind, und Informationen zu möglichen Problemen bereitstellt.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Teilen Sie die generierten Informationen nicht öffentlich es können sensible Daten enthalten sein. Geben Sie die Information nur an Personen weiter denen Sie vertrauen!</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation>Berichtsdatei generieren</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Logdatenbank</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation>Thing Einstellungen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation>Thing States Einstellungen</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation>Dieser Test zeigt den Trace-Pfad vom nymea Gerät zum nymea.io Server.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation>In diesem Abschnitt können Sie die Livelogs vom nymea-Servers sehen.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -336,8 +310,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -345,87 +319,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Logs</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation>Systeminformationen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Hostname</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Architektur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Kerneltyp</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Kernelversion</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Produkttyp</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Produktversion</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Systemlogs</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation>Anzeigen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>nymead Einstellungen</translation>
@@ -455,118 +441,128 @@ The download logs section of the debug interface</extracomment>
         <translation>MQTT-Richtlinien</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation>In diesem Abschnitt können Sie verschiedene Netzwerkkonnektivitätstests durchführen, um festzustellen, ob das Gerät, auf dem nymea ausgeführt wird, über eine vollständige Netzwerkkonnektivität verfügt.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation>Ping</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation>Dieser Test führt vier Ping-Versuche zum Server nymea.io durch.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation>Start ping-Test</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation>DNS-Suche</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation>Dieser Test macht einen dynamischen Nameserver-Lookup für nymea.io.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation>Start DNS-Lookup-Test</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation>Trace-Pfad</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation>Starten Sie den Trace-Pfad-Test</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation>Server-Live-Log</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation>Start Logs</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation>Log-Filter</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation>Log-Filter Plug-Ins</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation>Veröffentlicht unter der GNU GENERAL PUBLIC LICENSE Version 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Veröffentlicht unter der GNU GENERAL PUBLIC LICENSE Version 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Fehler %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Die Datei &quot;%1&quot; konnte nicht gefunden werden.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Die Datei &quot;% 1&quot; konnte nicht geöffnet werden.</translation>

--- a/translations/nymead-en_US.ts
+++ b/translations/nymead-en_US.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -69,66 +64,75 @@ for your environment.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -136,190 +140,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -327,8 +302,8 @@ The downloads section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -336,87 +311,99 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
@@ -446,118 +433,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation type="unfinished"></translation>

--- a/translations/nymead-es.ts
+++ b/translations/nymead-es.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Notificaciones en la nube</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Identificación de usuario</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Texto de mensaje</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Enviar notificación</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>conectado</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Conexión modificada</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea es un servidor de código abierto IoT (Internet de las cosas) que permite 
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Ejecute nymea en primer plano, no como daemon.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Especifique un archivo de registro en el que escribir, si esta opción no está especificada, se imprimirán los registros de forma estándar.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Si se ha especificado, todas las interfaces D-Bus estarán conectadas a la sesión en lugar de al bus de sistema.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Eliminación de fallos de nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>Interfaz de eliminación de fallos de nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Bienvenido a la interfaz de eliminación de fallos.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>La interfaz de eliminación de fallos ha sido diseñada para ofrecer una opción sencilla de conseguir información útil acerca de la ejecución del servidor de nymea.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Tenga en cuenta que la interfaz de eliminación de fallos supone un riesgo de seguridad y podría accederse a datos sensibles.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Información del servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Usuario</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Elaborado con la versión Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Versión de tiempo de ejecución Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Nombre de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Versión de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Directorio de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Datos de aplicación de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Datos de usuario de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Datos comunes de Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Nombre del servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Versión del servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>Versión JSON-RPC</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Zona horaria</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Servidor UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Ruta de ajustes</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Ruta de traducciones</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Base da datos de registro</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Descargas</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Registros</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Descarga</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Registros de sistema</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>Ajustes nymea</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Publicado en la LICENCIA PÚBLICA GENERAL GNU, versión 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Publicado en la LICENCIA PÚBLICA GENERAL GNU, versión 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Error  1%</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Imposible encontrar el archivo &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Imposible abrir el archivo &quot;%1&quot;.</translation>

--- a/translations/nymead-fi.ts
+++ b/translations/nymead-fi.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Pilvi-ilmoitukset</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Käyttäjätunnus</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Laite</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Otsikko</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Viestin teksti</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Lähetä ilmoitus</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>yhdistetty</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Yhdistetty muutettiin</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea on avoimen lähdekoodin IoT (Internet of Things) -palvelin, joka mahdollis
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Aja nymead edustalla, älä daemonina.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Määritä kirjoitettava lokitiedosto, jos tätä vaihtoehtoa ei ole määritetty, lokit tulostetaan vakiotulostuksena.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Jos määritetty, kaikki D-väylä-liittymät yhdistetään istuntoväylään järjestelmäväylän sijaan.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Debug nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>nymea debug -liittymä</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Tervetuloa debug-liittymään.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Tämä debug-liittymä suunniteltiin tarjoamaan helppo mahdollisuus saada hyödyllistä tietoa nymea-palvelimen ajamisesta.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Huomaa, että tämä debug-liittymä on turvallisuusriski ja saattaa tarjota pääsyn arkaluonteisiin tietoihin.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Palvelintiedot</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Käyttäjä</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Kootti Qt-versiolla</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Qt-ajoaikaversio</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Käsky</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-nimi</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-versio</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-hakemisto</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-sovellustiedot</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-käyttäjätiedot</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap - yleiset tiedot</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Palvelimen nimi</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Palvelimen versio</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>JSON-RPC-versio</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Kieli</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Aikavyöhyke</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Palvelin-UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Asetuspolku</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Käännöspolku</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Lokitietokanta</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Lataukset</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Lokit</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Lataa</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Järjestelmälokit</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>nymead-asetukset</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Julkaistu GNU GENERAL PUBLIC LICENSE, version 2 alla. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Julkaistu GNU GENERAL PUBLIC LICENSE, version 2 alla.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Virhe %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Tiedostoa &quot;&amp;1&quot; ei löytynyt.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Tiedostoa &quot;&amp;1&quot; ei voitu avata.</translation>

--- a/translations/nymead-fr.ts
+++ b/translations/nymead-fr.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Notification de cloud</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Utilisateur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Paramètres de l&apos;appareil</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Texte du message</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Notification d&apos;envoi</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>connecté</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Connecté modifié</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea est un serveur IoT (Internet of Things) open source, qui permet de contrô
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Exécutez nymead au premier plan, pas en tant que démon.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Spécifiez un fichier journal dans lequel écrire, si cette option n&apos;est pas spécifiée, les jounaux seront imprimés sur la sortie standard.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Si spécifié, toutes les interfaces D-Bus seront liées au bus de session au lieu du bus système.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>Débogage nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>Interface de débogage nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Bienvenue dans l&apos;interface de débogage.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Cette interface de débogage a été conçue pour faciliter l&apos;obtention d&apos;informations utiles sur le serveur nymea en cours d&apos;exécution.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Sachez que cette interface de débogage est un risque pour la sécurité et pourrait donner accès à des données sensibles.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Informations serveur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Utilisateur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Compilé avec la version Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Version d&apos;exécution Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Commande</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Nom snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Version snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Répertoire snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Données d&apos;application snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Données utilisateur snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Données de commande snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Nom du serveur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Version du serveur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>Version JSON-RPC</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Langue</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Zone de temps</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>UUID du serveur</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Chemin de paramétrage</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Chemin des traductions</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Base de données journal</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Téléchargements</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Journaux</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Téléchargement</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Journaux système</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>Paramètres nymead</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Publié sous la licence GNU GENERAL PUBLIC Version 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Publié sous la licence GNU GENERAL PUBLIC Version 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Erreur %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Fichier &quot;%1&quot; introuvable.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Impossible d&apos;ouvrir le fichier &quot;%1&quot;.</translation>

--- a/translations/nymead-it.ts
+++ b/translations/nymead-it.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Notifiche cloud</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>ID utente</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Titolo</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Testo del messaggio</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Invia notifica</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>connesso</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Connesso modificato</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea è un server IoT (Internet of Things) open source, che consente di control
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Esegui nymead in primo piano, non come demone.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Specificare un file di registro in cui scrivere, se questa opzione non è specificata, i registri verranno stampati sullo standard output.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Se specificato, tutte le interfacce bus D saranno associate al bus di sessione anziché al bus di sistema.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>debug nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>interfaccia di debug nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Benvenuti nell&apos;interfaccia di debug.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Questa interfaccia di debug è stata progettata per fornire una facile possibilità di ottenere informazioni utili sul server nymea in esecuzione.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Nota che questa interfaccia di debug è un rischio per la sicurezza e potrebbe offrire l&apos;accesso a dati sensibili.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Informazioni sul sever</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Utente</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Compilato con la versione Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Versione runtime Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Comando</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Nome snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Versione snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Directory snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Dati applicativo snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Dati utente snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Dati comuni snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Nome del server</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Versione del server</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>Versione JSON-RPC</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Lingua</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Fuso orario</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Server UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Percorso delle impostazioni</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Percorso delle traduzioni</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Registro database</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Log</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Log di sistema</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>Impostazioni nymead</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Rilasciato su licenza GNU General Public License versione 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Rilasciato su licenza GNU General Public License versione 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Errore %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>File &quot;%1&quot; non trovato.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Impossibile aprire il file &quot;%1&quot;.</translation>

--- a/translations/nymead-nl.ts
+++ b/translations/nymead-nl.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Cloud-berichten</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>Gebruikers-ID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Apparaat</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Berichttekst</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Bericht versturen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>verbonden</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Verbonden gewijzigd</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea is een open source IoT-server (IoT: Internet der dingen), waarmee zeer vee
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>nymead op de voorgrond - en niet als daemon uitvoeren.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>Specificeer een logbestand waarnaar geschreven kan worden. Als deze optie niet is gespecificeerd, worden logbestanden naar de standaarduitvoer geschreven.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Indien gespecificeerd, worden alle D-businterfaces gebonden aan de sessiebus, en niet aan de systeembus.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>nymea debuggen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>nymea debug-interface</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Welkom bij de debug-interface.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Deze debug-interface is bedoeld om gemakkelijk nuttige informatie over de inwerking zijnde nymea-server te krijgen.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>Besef wel dat deze debug-interface een beveiligingsrisico inhoudt, waarmee mogelijk toegang tot vertrouwelijke gegevens kan worden verkregen.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Serverinformatie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Gebruiker</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>Gecompileerd met Qt-versie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>Qt-runtimeversie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>Opdracht</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-naam</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-versie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-directory</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-toepassingsgegevens</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Snap-gebruikersgegevens</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Gemeenschappelijke gegevens voor Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Servernaam</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Serverversie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>JSON-RPC-versie</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Taal</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Tijdzone</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>Server-UUID</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>Pad naar instellingen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>Pad naar vertalingen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Log-database</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Downloads</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Logboeken</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Download</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Systeemlogboeken</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>nymead-instellingen</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Uitgebracht onder de GNU GENERAL PUBLIC LICENSE versie 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Uitgebracht onder de GNU GENERAL PUBLIC LICENSE versie 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Fout %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Bestand &quot;%1&quot; kon niet worden gevonden.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Bestand &quot;%1&quot; kon niet worden geopend.</translation>

--- a/translations/nymead-pt.ts
+++ b/translations/nymead-pt.ts
@@ -4,52 +4,47 @@
 <context>
     <name>CloudNotifications</name>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="63"/>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="128"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="57"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="121"/>
         <source>Cloud Notifications</source>
         <translation>Notificações de nuvem</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="69"/>
         <source>User ID</source>
         <translation>ID de utilizador</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="81"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="75"/>
         <source>Device</source>
         <translation>Dispositivo</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="85"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="97"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="91"/>
         <source>Message text</source>
         <translation>Texto de mensagem</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="107"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="101"/>
         <source>Send notification</source>
         <translation>Enviar notificação</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="116"/>
+        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="110"/>
         <source>connected</source>
         <translation>ligado</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/cloud/cloudnotifications.cpp" line="118"/>
-        <source>Connected changed</source>
-        <translation>Ligado alterado</translation>
     </message>
 </context>
 <context>
     <name>ThingManagerImplementation</name>
     <message>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="258"/>
-        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="1749"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="305"/>
+        <location filename="../libnymea-core/integrations/thingmanagerimplementation.cpp" line="2086"/>
         <source>The plugin for this thing is not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -57,7 +52,7 @@
 <context>
     <name>nymea</name>
     <message>
-        <location filename="../server/main.cpp" line="86"/>
+        <location filename="../server/main.cpp" line="87"/>
         <source>
 nymea is an open source IoT (Internet of Things) server, 
 which allows to control a lot of different devices from many different 
@@ -72,66 +67,75 @@ nymea é um servidor IoT (Internet das Coisas) de código aberto, que permite co
 </translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="98"/>
+        <location filename="../server/main.cpp" line="99"/>
         <source>Run nymead in the foreground, not as daemon.</source>
         <translation>Execute nymead em primeiro plano, não como daemon.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="101"/>
-        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Warnings&quot; to address warnings.
-Examples:
--d AWSTraffic
--d NoDeviceManager
--d NoBluetoothWarnings
-
-Categories are:</source>
+        <location filename="../server/main.cpp" line="102"/>
+        <source>Disables logging all debug, info and warning categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="113"/>
-        <source>Enables all debug categories except *Traffic and *Debug categories. Single debug categories can be disabled again with -d parameter.</source>
+        <location filename="../server/main.cpp" line="105"/>
+        <source>Enables all info and debug categories except *Traffic and *Debug categories.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="116"/>
+        <location filename="../server/main.cpp" line="108"/>
         <source>Specify a log file to write to, if this option is not specified, logs will be printed to the standard output.</source>
         <translation>﻿Especifique um ficheiro de registo para gravar, se essa opção não for especificada, os registos serão impressos na saída padrão.</translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="119"/>
+        <location filename="../server/main.cpp" line="111"/>
         <source>Log output is colorized by default. Use this option to disable colors.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../server/main.cpp" line="122"/>
+        <location filename="../server/main.cpp" line="114"/>
         <source>If specified, all D-Bus interfaces will be bound to the session bus instead of the system bus.</source>
         <translation>Se especificado, todas as interfaces do D-Bus serão ligadas ao barramento da sessão em vez do barramento do sistema.</translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="117"/>
+        <source>Debug categories to enable. Prefix with &quot;No&quot; to disable. Suffix with &quot;Info&quot; or &quot;Warnings&quot; to address info and warning messages. Enabling a debug category will implicitly enable the according info category.
+Examples:
+-d ThingManager
+-d NoApplicationInfo
+
+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../server/main.cpp" line="121"/>
+        <source>Additional interfaces to listen on. In nymea URI format (e.g. nymeas://127.0.0.2:7777). Note that such interfaces will not require any authentication as they are intended to be used for automated testing only.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>nymeaserver::DebugServerHandler</name>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="847"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1883"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1941"/>
         <source>Debug nymea</source>
         <extracomment>The header title of the debug server interface</extracomment>
         <translation>﻿Depuração nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="864"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="918"/>
         <source>nymea debug interface</source>
         <extracomment>The main title of the debug server interface</extracomment>
         <translation>Interface depuração nymea</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="877"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="931"/>
         <source>Information</source>
         <extracomment>The name of the section tab in the debug server interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="893"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1624"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="947"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
         <source>Network</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -139,190 +143,161 @@ The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="916"/>
-        <source>Welcome to the debug interface.</source>
-        <extracomment>The welcome message of the debug interface</extracomment>
-        <translation>Bem-vindo à interface debug.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="917"/>
-        <source>This debug interface was designed to provide an easy possibility to get helpful information about the running nymea server.</source>
-        <translation>Esta interface de depuração foi projetada para fornecer uma possibilidade fácil de obter informações úteis sobre o servidor nymea em execução.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="933"/>
-        <source>Be aware that this debug interface is a security risk and could offer access to sensible data.</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation>﻿Esteja ciente que﻿ esta interface de depuração representa um risco de segurança e pode oferecer acesso a dados sensíveis.</translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="941"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="991"/>
         <source>Server information</source>
         <extracomment>The server information section of the debug interface</extracomment>
         <translation>Informação do servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="996"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1046"/>
         <source>User</source>
         <extracomment>The user name in the server infromation section of the debug interface</extracomment>
         <translation>Utilizador</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1008"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1058"/>
         <source>Compiled with Qt version</source>
         <extracomment>The Qt build version description in the server infromation section of the debug interface</extracomment>
         <translation>﻿Compilado com a versão Qt</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1014"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
         <source>Qt runtime version</source>
         <extracomment>The Qt runtime version description in the server infromation section of the debug interface</extracomment>
         <translation>﻿Versão de tempo de execução Qt﻿</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1002"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1052"/>
         <source>Command</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation>﻿Comando</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1023"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1073"/>
         <source>Snap name</source>
         <extracomment>The snap name description in the server infromation section of the debug interface</extracomment>
         <translation>Nome Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1029"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1079"/>
         <source>Snap version</source>
         <extracomment>The snap version description in the server infromation section of the debug interface</extracomment>
         <translation>Versão Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1035"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1085"/>
         <source>Snap directory</source>
         <extracomment>The snap directory description in the server infromation section of the debug interface</extracomment>
         <translation>Diretório Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1041"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1091"/>
         <source>Snap application data</source>
         <extracomment>The snap application data description in the server infromation section of the debug interface</extracomment>
         <translation>Dados da aplicação Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1047"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1097"/>
         <source>Snap user data</source>
         <extracomment>The snap user data description in the server infromation section of the debug interface</extracomment>
         <translation>Dados do utilizador Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1053"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1103"/>
         <source>Snap common data</source>
         <extracomment>The snap common data description in the server infromation section of the debug interface</extracomment>
         <translation>Dados comuns Snap</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="948"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="998"/>
         <source>Server name</source>
         <extracomment>The server name description in the server infromation section of the debug interface</extracomment>
         <translation>Nome do servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="954"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1004"/>
         <source>Server version</source>
         <extracomment>The server version description in the server infromation section of the debug interface</extracomment>
         <translation>Versão do servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="960"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1010"/>
         <source>JSON-RPC version</source>
         <extracomment>The API version description in the server infromation section of the debug interface</extracomment>
         <translation>Versão JSON-RPC</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="966"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1016"/>
         <source>Language</source>
         <extracomment>The language description in the server infromation section of the debug interface</extracomment>
         <translation>Idioma</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="972"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1022"/>
         <source>Timezone</source>
         <extracomment>The timezone description in the server infromation section of the debug interface</extracomment>
         <translation>Fuso horário</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="978"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1028"/>
         <source>Server UUID</source>
         <extracomment>The server id description in the server infromation section of the debug interface</extracomment>
         <translation>UUID servidor</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="984"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1034"/>
         <source>Settings path</source>
         <extracomment>The settings path description in the server infromation section of the debug interface</extracomment>
         <translation>﻿Caminho de configurações</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="990"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1040"/>
         <source>Translations path</source>
         <extracomment>The translation path description in the server infromation section of the debug interface</extracomment>
         <translation>﻿Caminho de traduções</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1115"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1165"/>
         <source>Generate report</source>
         <extracomment>In the server information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1118"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
         <source>If you want to provide all the debug information to a developer, you can generate a report file, which contains all information needed for reproducing a system and get information about possible problems.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1135"/>
-        <source>Do not share these generated information public, since they can contain sensible data and should be shared very carefully and only with people you trust!</source>
-        <extracomment>The warning message of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1146"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1196"/>
         <source>Generate report file</source>
         <extracomment>The generate debug report button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1184"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1234"/>
         <source>Log database</source>
         <extracomment>The log databse download description of the debug interface</extracomment>
         <translation>Banco de dados de registo</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
         <source>Thing settings</source>
         <extracomment>The thing settings download description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1370"/>
-        <source>Thing states settings</source>
-        <extracomment>The thing states settings download description of the debug interface</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1692"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1742"/>
         <source>This test shows the trace path from the nymea device to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1731"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1781"/>
         <source>This section allows you to see the live logs of the nymea server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="885"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1168"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="939"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1218"/>
         <source>Downloads</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -330,8 +305,8 @@ The downloads section of the debug interface</extracomment>
         <translation>Descargas</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="901"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1173"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="955"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1223"/>
         <source>Logs</source>
         <extracomment>The name of the section tab in the debug server interface
 ----------
@@ -339,87 +314,99 @@ The download logs section of the debug interface</extracomment>
         <translation>Registos</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1064"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="983"/>
+        <source>Please note that this debug interface may allow accessing sensitive data about the nymea system and connected devices and services. It is recommended to disable it again when not needed any more.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1114"/>
         <source>System information</source>
         <extracomment>The system information section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1071"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1121"/>
         <source>Hostname</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1082"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1132"/>
         <source>Architecture</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1088"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1138"/>
         <source>Kernel type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1094"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1144"/>
         <source>Kernel version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1100"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1150"/>
         <source>Product type</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1106"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1156"/>
         <source>Product version</source>
         <extracomment>The command description in the server infromation section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1206"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1236"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1289"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1185"/>
+        <source>Please note that the generated debug report may contain sensitive data about the nymea system and connected devices and services.</source>
+        <extracomment>The warning message of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1256"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1286"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1339"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1389"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1439"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1489"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1539"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1588"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1638"/>
         <source>Download</source>
         <extracomment>The download button description of the debug interface</extracomment>
         <translation>Descarga</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1220"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
         <source>System logs</source>
         <extracomment>The syslog download description of the debug interface</extracomment>
         <translation>Registos do sistema</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1249"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1305"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1299"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1355"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1405"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1455"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1505"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1555"/>
         <location filename="../libnymea-core/debugserverhandler.cpp" line="1604"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1654"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1260"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1310"/>
         <source>Settings</source>
         <extracomment>The settings download section title of the debug interface</extracomment>
         <translation>﻿Configurações</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1270"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1320"/>
         <source>nymead settings</source>
         <extracomment>The nymead settings download description of the debug interface</extracomment>
         <translation>﻿Configurações nymead</translation>
@@ -449,118 +436,128 @@ The download logs section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1627"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1619"/>
+        <source>IO Connections</source>
+        <extracomment>The MQTT policies download description of the debug interface</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1677"/>
         <source>This section allows you to perform different network connectivity tests in order to find out if the device where nymea is running has full network connectivity.</source>
         <extracomment>The network section description of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1633"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1683"/>
         <source>Ping</source>
         <extracomment>The ping section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1636"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1686"/>
         <source>This test makes four ping attempts to the nymea.io server.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1645"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1695"/>
         <source>Start ping test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1661"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1711"/>
         <source>DNS lookup</source>
         <extracomment>The DNS lookup section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1664"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1714"/>
         <source>This test makes a dynamic name server lookup for nymea.io.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1674"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1724"/>
         <source>Start DNS lookup test</source>
         <extracomment>The ping button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1689"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1739"/>
         <source>Trace path</source>
         <extracomment>The trace section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1701"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1751"/>
         <source>Start trace path test</source>
         <extracomment>The trace path button text of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1728"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1778"/>
         <source>Server live logs</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1743"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1793"/>
         <source>Start logs</source>
         <extracomment>The connect button for the log stream of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1782"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1832"/>
         <source>Logging filters</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1814"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1871"/>
         <source>Logging filters plugins</source>
         <extracomment>The network section of the debug interface</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1852"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1926"/>
-        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1910"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 3.</source>
         <extracomment>The footer license note of the debug interface</extracomment>
+        <translation type="unfinished">Lançado sob a LICENÇA PÚBLICA GERAL do GNU﻿ Versão 2. {3.?}</translation>
+    </message>
+    <message>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1984"/>
+        <source>Released under the GNU GENERAL PUBLIC LICENSE Version 2.</source>
         <translation>Lançado sob a LICENÇA PÚBLICA GERAL do GNU﻿ Versão 2.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="1896"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="1954"/>
         <source>Error  %1</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the error code ie.e 404</extracomment>
         <translation>Erro %1</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="87"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="119"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="150"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="179"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="208"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="237"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="266"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="295"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="325"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="88"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="120"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="151"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="180"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="209"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="239"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="268"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="298"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="327"/>
         <source>Could not find file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Não foi possível encontrar ficheiro ﻿&quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="96"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="127"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="158"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="187"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="216"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="245"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="274"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="303"/>
-        <location filename="../libnymea-core/debugserverhandler.cpp" line="333"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="97"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="128"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="159"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="188"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="217"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="247"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="276"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="306"/>
+        <location filename="../libnymea-core/debugserverhandler.cpp" line="335"/>
         <source>Could not open file &quot;%1&quot;.</source>
         <extracomment>The HTTP error message of the debug interface. The %1 represents the file name.</extracomment>
         <translation>Não foi possível abrir ficheiro ﻿&quot;%1&quot;.</translation>


### PR DESCRIPTION
This disables the info category by default, with the exception of the Application category. And allows enabling info and debug categories indidually. Also adds a -q (quiet) flag to silence even warnings. For convenience, enabling a debug category will implicitly enable the according info and warning categories.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
