### PR TITLE
Enqueue priority jobs instead of prepending

### DIFF
--- a/libnymea-core/logging/logengine.h
+++ b/libnymea-core/logging/logengine.h
@@ -129,6 +129,7 @@ private:
     QHash<QString, QList<DatabaseJob*>> m_flaggedJobs;
 
     QList<DatabaseJob*> m_jobQueue;
+    QList<DatabaseJob*> m_priorityJobQueue;
     DatabaseJob *m_currentJob = nullptr;
     QFutureWatcher<DatabaseJob*> m_jobWatcher;
 };


### PR DESCRIPTION
Keeping a second queue for priority jobs instead of just prepending them to keep them properly sorted if multiple priority jobs are coming in.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
