### PR TITLE
Create indices on entries table of log db

### DIFF
--- a/libnymea-core/logging/logengine.cpp
+++ b/libnymea-core/logging/logengine.cpp
@@ -817,8 +817,17 @@ bool LogEngine::initDB(const QString &username, const QString &password)
             m_db.close();
             return false;
         }
+    }
 
-
+    m_db.exec("CREATE INDEX IF NOT EXISTS idx_query_single_thing ON entries (thingId);");
+    if (m_db.lastError().isValid()) {
+        qCWarning(dcLogEngine()) << "Error creating entries table thing index in log database. Driver error:" << m_db.lastError().driverText() << "Database error:" << m_db.lastError().databaseText();
+        return false;
+    }
+    m_db.exec("CREATE INDEX IF NOT EXISTS idx_query_single_type ON entries (typeId, thingId);");
+    if (m_db.lastError().isValid()) {
+        qCWarning(dcLogEngine()) << "Error creating entries table state index in log database. Driver error:" << m_db.lastError().driverText() << "Database error:" << m_db.lastError().databaseText();
+        return false;
     }
 
     qCDebug(dcLogEngine) << "Initialized logging DB successfully. (maximum DB size:" << m_dbMaxSize << ")";


### PR DESCRIPTION
This greatly improves performance when querying logs for a single thing or a single state/event/action.

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
