### PR TITLE
Enable logging for signal strength by default

### DIFF
--- a/libnymea/interfaces/wirelessconnectable.json
+++ b/libnymea/interfaces/wirelessconnectable.json
@@ -8,7 +8,8 @@
             "unit": "Percentage",
             "minValue": 0,
             "maxValue": 100,
-            "optional": true
+            "optional": true,
+            "logged": true
         }
     ]
 }

--- a/tests/auto/logging/testlogging.cpp
+++ b/tests/auto/logging/testlogging.cpp
@@ -180,7 +180,7 @@ void TestLogging::stateChangeLogs_data()
     QTest::addColumn<bool>("expectLogEntry");
 
     QTest::newRow("logged state") << mockConnectedStateTypeId << "connected" << QVariant(false) << QVariant(true) << true;
-    QTest::newRow("not logged state") << mockSignalStrengthStateTypeId << "signalStrength" << QVariant(10) << QVariant(20) << false;
+    QTest::newRow("not logged state") << mockDoubleStateTypeId << "double" << QVariant(10) << QVariant(20) << false;
 }
 
 void TestLogging::stateChangeLogs()


### PR DESCRIPTION
Since the new log engine this isn't that heavy on the resources any more

nymea:core pull request checklist:

- [ ] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [ ] Did you update translations (cd builddir && make lupdate)?

- [ ] Did you update the website/documentation?
