### PR TITLE
Allow to build nymead using custom version independent from dpkg

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -26,6 +26,9 @@ endif
 DPKG_EXPORT_BUILDFLAGS = 1
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
+NYMEA_DPKG_VERSION := $(shell dpkg-parsechangelog -SVersion)
+QMAKE_ADDITIONAL_ARGS += NYMEA_VERSION=$(NYMEA_DPKG_VERSION)
+
 include /usr/share/dpkg/buildflags.mk
 
 PREPROCESS_FILES := $(wildcard debian/*.in)
@@ -34,7 +37,7 @@ $(PREPROCESS_FILES:.in=): %: %.in
 	sed 's,/@DEB_HOST_MULTIARCH@,$(DEB_HOST_MULTIARCH:%=/%),g' $< > $@
 
 override_dh_auto_configure:
-	dh_auto_configure -- "$(QMAKE_ADDITIONAL_ARGS)"
+	dh_auto_configure -- $(QMAKE_ADDITIONAL_ARGS)
 
 override_dh_auto_build:
 	make -j$(DEB_PARALLEL_JOBS) $(MAKE_TARGETS)

--- a/nymea.pro
+++ b/nymea.pro
@@ -1,7 +1,13 @@
 include(nymea.pri)
 
 # Parse and export NYMEA_VERSION_STRING
-NYMEA_VERSION_STRING=$$system('dpkg-parsechangelog | sed -n -e "s/^Version: //p"')
+isEmpty(NYMEA_VERSION) {
+    NYMEA_VERSION_STRING='development'
+    message("The variable NYMEA_VERSION is unset. Using \"$${NYMEA_VERSION_STRING}\" as default version.")
+} else {
+    # qmake NYMEA_VERSION=1.x.x-custom
+    NYMEA_VERSION_STRING="$${NYMEA_VERSION}"
+}
 
 # define protocol versions
 JSON_PROTOCOL_VERSION_MAJOR=8
@@ -13,7 +19,6 @@ LIBNYMEA_API_VERSION_PATCH=0
 LIBNYMEA_API_VERSION="$${LIBNYMEA_API_VERSION_MAJOR}.$${LIBNYMEA_API_VERSION_MINOR}.$${LIBNYMEA_API_VERSION_PATCH}"
 
 QMAKE_SUBSTITUTES += version.h.in
-
 
 TEMPLATE=subdirs
 


### PR DESCRIPTION
This patch allows to define the nymea version for platforms not depending on debian packages (i.e. yocto). 

nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.

- [x] Did you update translations (cd builddir && make lupdate)?

- [x] Did you update the website/documentation?
