### PR TITLE
Log proper RPC method name for the initial setup

### DIFF
--- a/libnymea-core/jsonrpc/jsonrpcserverimplementation.cpp
+++ b/libnymea-core/jsonrpc/jsonrpcserverimplementation.cpp
@@ -621,7 +621,7 @@ void JsonRPCServerImplementation::processJsonPacket(TransportInterface *interfac
         // if there is no user in the system yet, let's fail unless this is a special method for authentication itself
         if (NymeaCore::instance()->userManager()->initRequired()) {
             if (!authExemptMethodsNoUser.contains(methodString) && (token.isEmpty() || !NymeaCore::instance()->userManager()->verifyToken(token))) {
-                sendUnauthorizedResponse(interface, clientId, commandId, "Initial setup required. Call Users.CreateUser first.");
+                sendUnauthorizedResponse(interface, clientId, commandId, "Initial setup required. Call JSONRPC.CreateUser first.");
                 qCWarning(dcJsonRpc()) << "Initial setup required but client does not call the setup. Dropping connection.";
                 interface->terminateClientConnection(clientId);
                 qCWarning(dcJsonRpc()) << "Staring connection lockdown timer";


### PR DESCRIPTION
nymea:core pull request checklist:

- [x] Did you test the changes? If not (e.g. absence of required hardware), please mention a person to confirm it has been tested.
- [x] Did you update translations (cd builddir && make lupdate)?
- [x] Did you update the website/documentation?

nope, need to do this eventually if this is really required for the log-message change.

---

https://www.nymea.io/documentation/resources/api/#j-s-o-n-r-p-c-create-user says 

> JSONRPC.CreateUser
> Create a new user in the API. This is only allowed to be called when the initial setup is required. To create additional users, use Users.CreateUser instead.

And based on my own experience, it seems JSONRPC.CreateUser really needs to be used instead of Users.CreateUser. However, I'm running version 1.7.0, but I guess this is still true.